### PR TITLE
Issue 0-8: add shared layout scaffold with header and footer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -23,4 +23,5 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { Footer } from "@/components/footer";
+import { Header } from "@/components/header";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -13,7 +15,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-screen bg-background text-foreground">
+        <div className="flex min-h-screen flex-col">
+          <Header />
+          <div className="flex-1">{children}</div>
+          <Footer />
+        </div>
+      </body>
     </html>
   );
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,9 @@
+export function Footer() {
+  return (
+    <footer className="border-t border-black/10 bg-white/80">
+      <div className="mx-auto w-full max-w-5xl px-6 py-4 text-sm text-black/60">
+        Footer placeholder
+      </div>
+    </footer>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,10 @@
+export function Header() {
+  return (
+    <header className="border-b border-black/10 bg-white/80">
+      <div className="mx-auto w-full max-w-5xl px-6 py-4">
+        <p className="text-sm font-semibold">Settled Field Platform</p>
+        <p className="text-xs text-black/60">Shared header placeholder</p>
+      </div>
+    </header>
+  );
+}

--- a/components/route-placeholder.tsx
+++ b/components/route-placeholder.tsx
@@ -8,9 +8,11 @@ export function RoutePlaceholder({
   path,
 }: RoutePlaceholderProps) {
   return (
-    <main>
-      <h1>{title} placeholder</h1>
-      <p>Route: {path}</p>
+    <main className="mx-auto flex w-full max-w-5xl flex-1 items-center px-6 py-16">
+      <div className="w-full rounded-xl border border-black/10 bg-white p-8">
+        <h1 className="text-3xl font-semibold">{title} placeholder</h1>
+        <p className="mt-3 text-sm text-black/60">Route: {path}</p>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
Added the base shared layout scaffold for the app.

## Related Issue
Closes #8 

## Changes
- added shared Header and Footer components
- applied the shared shell in the root layout
- updated placeholder route rendering to use a consistent wrapper
- kept existing routes and behavior intact

## Verification checklist
- [x] shared header exists
- [x] shared footer exists
- [x] root layout applies them across routes
- [x] existing routes still render
- [x] `npm run build` passes
- [x] `npm run lint` passes

## Notes
This is scaffold-only and intentionally minimal. Final branding and navigation polish will come later.