### PR TITLE
Issue 0-9: add session-based admin auth and route protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,16 @@
 # Database
-DATABASE_URL=postgres://gacurl:p33p33P@NTS@HOST:PORT/DATABASE
+DATABASE_URL=postgres://USER:PASSWORD@HOST:PORT/DATABASE
 
-# Stripe (placeholders only)
+# Stripe (placeholders for future use)
 STRIPE_SECRET_KEY=sk_test_placeholder
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
-# Admin (basic auth for MVP)
+# Admin (single-user MVP)
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=change_me
+
+# Admin session
+ADMIN_SESSION_SECRET=replace_with_a_long_random_secret

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,4 +1,15 @@
-export default function AdminLoginPage() {
+type AdminLoginPageProps = {
+  searchParams?: Promise<{
+    error?: string;
+  }>;
+};
+
+export default async function AdminLoginPage({
+  searchParams,
+}: AdminLoginPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const showError = resolvedSearchParams?.error === "invalid";
+
   return (
     <main
       style={{
@@ -39,6 +50,18 @@ export default function AdminLoginPage() {
         >
           Sign in to access the admin area.
         </p>
+
+        {showError ? (
+          <p
+            style={{
+              margin: "0 0 1rem",
+              color: "#b91c1c",
+              lineHeight: 1.5,
+            }}
+          >
+            Invalid email or password.
+          </p>
+        ) : null}
 
         <form action="/api/admin/login" method="post">
           <div style={{ marginBottom: "1rem" }}>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,18 @@
-import { RoutePlaceholder } from "@/components/route-placeholder";
-
 export default function AdminPage() {
-  return <RoutePlaceholder title="Admin" path="/admin" />;
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-1 items-center px-6 py-16">
+      <div className="w-full rounded-xl border border-black/10 bg-white p-8">
+        <h1 className="text-3xl font-semibold">Admin placeholder</h1>
+        <p className="mt-3 text-sm text-black/60">Route: /admin</p>
+        <form action="/api/admin/logout" method="post" className="mt-6">
+          <button
+            type="submit"
+            className="rounded-md bg-black px-4 py-2 text-sm font-semibold text-white"
+          >
+            Log Out
+          </button>
+        </form>
+      </div>
+    </main>
+  );
 }

--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -1,16 +1,33 @@
+import { NextResponse } from "next/server";
+import {
+  areAdminCredentialsValid,
+  createAdminSessionValue,
+  getAdminSessionCookieName,
+  getAdminSessionCookieOptions,
+} from "@/lib/admin-auth";
+
 export async function POST(request: Request) {
   const formData = await request.formData();
   const email = formData.get("email");
   const password = formData.get("password");
 
-  if (
-    typeof email === "string" &&
-    typeof password === "string" &&
-    email === process.env.ADMIN_EMAIL &&
-    password === process.env.ADMIN_PASSWORD
-  ) {
-    return new Response("OK", { status: 200 });
+  if (areAdminCredentialsValid(email, password)) {
+    const sessionValue = createAdminSessionValue();
+
+    if (!sessionValue) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const response = NextResponse.redirect(new URL("/admin", request.url), 303);
+
+    response.cookies.set({
+      ...getAdminSessionCookieOptions(),
+      name: getAdminSessionCookieName(),
+      value: sessionValue,
+    });
+
+    return response;
   }
 
-  return new Response("Unauthorized", { status: 401 });
+  return NextResponse.redirect(new URL("/admin/login?error=invalid", request.url), 303);
 }

--- a/app/api/admin/logout/route.ts
+++ b/app/api/admin/logout/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import {
+  getAdminSessionCookieName,
+  getAdminSessionCookieOptions,
+} from "@/lib/admin-auth";
+
+export async function POST(request: Request) {
+  const response = NextResponse.redirect(new URL("/admin/login", request.url), 303);
+
+  response.cookies.set({
+    ...getAdminSessionCookieOptions(),
+    maxAge: 0,
+    name: getAdminSessionCookieName(),
+    value: "",
+  });
+
+  return response;
+}

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,0 +1,120 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const ADMIN_SESSION_COOKIE = "admin_session";
+const ADMIN_SESSION_DURATION_SECONDS = 60 * 60 * 8;
+
+function getSessionSecret() {
+  const adminEmail = process.env.ADMIN_EMAIL;
+  const adminPassword = process.env.ADMIN_PASSWORD;
+
+  if (!adminEmail || !adminPassword) {
+    return null;
+  }
+
+  return process.env.ADMIN_SESSION_SECRET ?? `${adminEmail}:${adminPassword}`;
+}
+
+function toBase64Url(value: string) {
+  return Buffer.from(value).toString("base64url");
+}
+
+function fromBase64Url(value: string) {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function signValue(value: string, secret: string) {
+  return createHmac("sha256", secret).update(value).digest("base64url");
+}
+
+function safeEqual(left: string, right: string) {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export function getAdminSessionCookieName() {
+  return ADMIN_SESSION_COOKIE;
+}
+
+export function getAdminSessionCookieOptions() {
+  return {
+    httpOnly: true,
+    maxAge: ADMIN_SESSION_DURATION_SECONDS,
+    path: "/",
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+  };
+}
+
+export function areAdminCredentialsValid(email: unknown, password: unknown) {
+  const adminEmail = process.env.ADMIN_EMAIL;
+  const adminPassword = process.env.ADMIN_PASSWORD;
+
+  if (
+    typeof email !== "string" ||
+    typeof password !== "string" ||
+    !adminEmail ||
+    !adminPassword
+  ) {
+    return false;
+  }
+
+  return safeEqual(email, adminEmail) && safeEqual(password, adminPassword);
+}
+
+export function createAdminSessionValue() {
+  const secret = getSessionSecret();
+
+  if (!secret) {
+    return null;
+  }
+
+  const payload = JSON.stringify({
+    exp: Date.now() + ADMIN_SESSION_DURATION_SECONDS * 1000,
+    sub: "admin",
+  });
+  const encodedPayload = toBase64Url(payload);
+  const signature = signValue(encodedPayload, secret);
+
+  return `${encodedPayload}.${signature}`;
+}
+
+export function isAdminSessionValueValid(value: string | undefined) {
+  if (!value) {
+    return false;
+  }
+
+  const secret = getSessionSecret();
+
+  if (!secret) {
+    return false;
+  }
+
+  const [encodedPayload, signature] = value.split(".");
+
+  if (!encodedPayload || !signature) {
+    return false;
+  }
+
+  const expectedSignature = signValue(encodedPayload, secret);
+
+  if (!safeEqual(signature, expectedSignature)) {
+    return false;
+  }
+
+  try {
+    const payload = JSON.parse(fromBase64Url(encodedPayload)) as {
+      exp?: number;
+      sub?: string;
+    };
+
+    return payload.sub === "admin" && typeof payload.exp === "number" && payload.exp > Date.now();
+  } catch {
+    return false;
+  }
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import {
+  getAdminSessionCookieName,
+  isAdminSessionValueValid,
+} from "@/lib/admin-auth";
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname === "/admin/login") {
+    return NextResponse.next();
+  }
+
+  const sessionValue = request.cookies.get(getAdminSessionCookieName())?.value;
+
+  if (isAdminSessionValueValid(sessionValue)) {
+    return NextResponse.next();
+  }
+
+  const loginUrl = new URL("/admin/login", request.url);
+  return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+  matcher: ["/admin/:path*"],
+};


### PR DESCRIPTION
## Summary
Added session-based admin authentication and protected admin routes.

## Related Issue
Closes #15 

## Changes
- added cookie-based admin session handling
- protected `/admin` routes while keeping `/admin/login` public
- added logout flow that clears the session
- updated login handling to redirect on valid or invalid credentials
- documented `ADMIN_SESSION_SECRET` in `.env.example`

## Verification checklist
- [x] valid login creates authenticated state
- [x] invalid login does not create authenticated state
- [x] unauthorized `/admin` access redirects to `/admin/login`
- [x] authorized admin can access `/admin`
- [x] logout clears session and blocks `/admin` again
- [x] `npm run build` passes
- [x] `npm run lint` passes

## Notes
This completes the single-admin session baseline for Milestone 0.