### PR TITLE
Issue 1-3: build summit page with register CTA

### DIFF
--- a/app/summit/page.tsx
+++ b/app/summit/page.tsx
@@ -1,5 +1,167 @@
-import { RoutePlaceholder } from "@/components/route-placeholder";
+import Link from "next/link";
 
 export default function SummitPage() {
-  return <RoutePlaceholder title="Summit" path="/summit" />;
+  return (
+    <>
+      <section
+        style={{
+          paddingTop: "var(--space-8)",
+          paddingBottom: "var(--space-8)",
+        }}
+      >
+        <h1
+          style={{
+            margin: "0 0 var(--space-4)",
+            color: "var(--color-primary)",
+            fontSize: "2.5rem",
+            lineHeight: 1.1,
+          }}
+        >
+          Settled on the Field Summit
+        </h1>
+        <p
+          style={{
+            maxWidth: "42rem",
+            margin: "0 0 var(--space-6)",
+            color: "var(--color-accent)",
+          }}
+        >
+          A focused event for people navigating transition and looking for a
+          clearer next move, grounded conversations, and practical direction.
+        </p>
+        <Link
+          href="/register"
+          style={{
+            display: "inline-block",
+            padding: "var(--space-4) var(--space-6)",
+            background: "var(--color-primary)",
+            color: "var(--color-background)",
+          }}
+        >
+          Register Now
+        </Link>
+      </section>
+
+      <section
+        style={{
+          paddingTop: "var(--space-8)",
+          paddingBottom: "var(--space-8)",
+        }}
+      >
+        <h2
+          style={{
+            margin: "0 0 var(--space-4)",
+            color: "var(--color-primary)",
+            fontSize: "1.5rem",
+          }}
+        >
+          Who It&apos;s For
+        </h2>
+        <ul
+          style={{
+            margin: "0",
+            paddingLeft: "1.25rem",
+            color: "var(--color-accent)",
+          }}
+        >
+          <li>Athletes preparing for life beyond the current season</li>
+          <li>Veterans navigating a new civilian chapter</li>
+          <li>Transitioning professionals looking for renewed direction</li>
+        </ul>
+      </section>
+
+      <section
+        style={{
+          paddingTop: "var(--space-8)",
+          paddingBottom: "var(--space-8)",
+        }}
+      >
+        <h2
+          style={{
+            margin: "0 0 var(--space-4)",
+            color: "var(--color-primary)",
+            fontSize: "1.5rem",
+          }}
+        >
+          What You&apos;ll Get
+        </h2>
+        <ul
+          style={{
+            margin: "0",
+            paddingLeft: "1.25rem",
+            color: "var(--color-accent)",
+          }}
+        >
+          <li>Direction</li>
+          <li>Clarity</li>
+          <li>Connection</li>
+          <li>Real conversations</li>
+        </ul>
+      </section>
+
+      <section
+        style={{
+          paddingTop: "var(--space-8)",
+          paddingBottom: "var(--space-8)",
+        }}
+      >
+        <h2
+          style={{
+            margin: "0 0 var(--space-4)",
+            color: "var(--color-primary)",
+            fontSize: "1.5rem",
+          }}
+        >
+          Structure and Experience
+        </h2>
+        <p
+          style={{
+            maxWidth: "42rem",
+            margin: "0",
+            color: "var(--color-accent)",
+          }}
+        >
+          Expect focused talks, experienced speakers, room for interaction, and
+          space to build meaningful connections with people facing similar
+          questions about what comes next.
+        </p>
+      </section>
+
+      <section
+        style={{
+          paddingTop: "var(--space-8)",
+          paddingBottom: "var(--space-8)",
+        }}
+      >
+        <h2
+          style={{
+            margin: "0 0 var(--space-4)",
+            color: "var(--color-primary)",
+            fontSize: "1.5rem",
+          }}
+        >
+          Ready to Join?
+        </h2>
+        <p
+          style={{
+            margin: "0 0 var(--space-6)",
+            color: "var(--color-accent)",
+          }}
+        >
+          Reserve your place and move into the next step with intention.
+        </p>
+        <Link
+          href="/register"
+          style={{
+            display: "inline-block",
+            padding: "var(--space-4) var(--space-6)",
+            background: "var(--color-background)",
+            color: "var(--color-primary)",
+          }}
+        >
+          Register Now
+        </Link>
+      </section>
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
Builds the summit page to support user decision-making with clear audience, value, and experience sections, and directs users to register.

## Related Issue
Closes #1-3

## Changes
- replaced summit placeholder with structured page
- added hero section with register CTA
- added “who it’s for” section
- added value and experience sections
- added final CTA linking to `/register`

## Verification
- [x] summit page renders without error
- [x] all sections visible in order
- [x] CTA visible and clickable
- [x] CTA routes to `/register`
- [x] layout persists across navigation

## Notes
- Next.js lockfile warning is non-blocking