### PR TITLE
Issue 1-5: add Vercel Analytics to root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/next";
 import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
 import "./globals.css";
@@ -25,6 +26,7 @@ export default function RootLayout({
         <footer>
           <Footer />
         </footer>
+        <Analytics />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "settled-field-platform",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "next": "16.2.2",
         "pg": "^8.20.0",
         "react": "19.2.4",
@@ -2014,6 +2015,48 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "next": "16.2.2",
     "pg": "^8.20.0",
     "react": "19.2.4",


### PR DESCRIPTION
## Summary
Adds Vercel Analytics to the root layout so page views are tracked globally across the app.

## Related Issue
Closes #24 

## Changes
- installed `@vercel/analytics`
- mounted analytics in `app/layout.tsx`
- updated package files from install

## Verification
- [ ] app builds without analytics-related errors
- [ ] `/` loads without error
- [ ] `/summit` loads without error
- [ ] `/register` loads without error
- [ ] Web Analytics is enabled and verified in Vercel after deploy

## Notes
- existing lockfile warning is unchanged and non-blocking
- existing dependency vulnerability is out of scope for this issue
- 