### PR TITLE
Issue 1-6: fix turbopack root for stable builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    root: path.join(__dirname),
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
Fixes Next.js workspace root inference by setting `turbopack.root` to the project directory, eliminating build warnings and stabilizing deploy behavior.

## Related Issue
Closes #25 

## Changes
- added `turbopack.root` configuration in `next.config.ts`

## Verification
- [x] app builds without root inference warning
- [x] `/`, `/summit`, `/register` return 200
- [x] navigation flow works end-to-end
- [x] Vercel Analytics script loads

## Notes
- production behavior verified via deployed routes and prior manual browser checks