### PR TITLE
Issue 2-1: Bring registration page into visual parity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,11 +1,14 @@
 :root {
   --color-background: #ffffff;
+  --color-surface: #f6f3ee;
+  --color-border: #d7d0c4;
   --color-text: #111111;
   --color-primary: #0a0a0a;
   --color-accent: #666666;
   --space-4: 1rem;
   --space-6: 1.5rem;
   --space-8: 2rem;
+  --space-12: 3rem;
   --content-width: 64rem;
 }
 
@@ -90,4 +93,208 @@ a {
 .shell-footer {
   color: var(--color-accent);
   margin: 0;
+}
+
+.register-page {
+  padding-top: var(--space-8);
+  padding-bottom: var(--space-8);
+}
+
+.register-page__intro {
+  max-width: 42rem;
+  margin-bottom: var(--space-8);
+}
+
+.register-page__eyebrow {
+  margin: 0 0 var(--space-4);
+  color: var(--color-accent);
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.register-page__title {
+  margin: 0 0 var(--space-4);
+  color: var(--color-primary);
+  max-width: 36rem;
+  font-size: 2.5rem;
+  line-height: 1.1;
+}
+
+.register-page__lede {
+  max-width: 40rem;
+  margin: 0;
+  color: var(--color-accent);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.register-page__grid {
+  display: grid;
+  gap: var(--space-12);
+}
+
+.register-form {
+  display: grid;
+  gap: var(--space-6);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.register-form__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: var(--space-6);
+  row-gap: 1.25rem;
+}
+
+.register-field {
+  display: grid;
+  gap: 0.625rem;
+  color: var(--color-primary);
+}
+
+.register-field span {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.register-field--full {
+  grid-column: 1 / -1;
+}
+
+.register-field input,
+.register-field textarea {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 0;
+  padding: 0.9375rem 1rem;
+  background: var(--color-background);
+  color: var(--color-text);
+  font: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  font-weight: 400;
+}
+
+.register-field input {
+  min-height: 3.25rem;
+}
+
+.register-field textarea {
+  resize: vertical;
+  min-height: 9rem;
+}
+
+.register-field input:focus,
+.register-field textarea:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.register-cta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--space-6);
+  padding-top: var(--space-8);
+  border-top: 1px solid var(--color-border);
+}
+
+.register-cta__content {
+  max-width: 32rem;
+}
+
+.register-cta h2,
+.register-panel h2 {
+  margin: 0 0 0.75rem;
+  color: var(--color-primary);
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.register-cta p,
+.register-panel p,
+.register-panel li {
+  color: var(--color-accent);
+  line-height: 1.5;
+}
+
+.register-cta p,
+.register-panel p,
+.register-panel ul,
+.register-panel ol {
+  margin: 0;
+}
+
+.register-cta__button {
+  display: inline-block;
+  border: 0;
+  min-height: 3.5rem;
+  padding: var(--space-4) var(--space-6);
+  background: var(--color-primary);
+  color: var(--color-background);
+  font: inherit;
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.register-sidebar {
+  display: grid;
+  gap: var(--space-8);
+  align-content: start;
+}
+
+.register-panel {
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.register-panel ul,
+.register-panel ol {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+}
+
+.register-panel__note {
+  padding-top: var(--space-6);
+}
+
+@media (min-width: 64rem) {
+  .register-page__grid {
+    grid-template-columns: minmax(0, 1.7fr) minmax(18rem, 1fr);
+    align-items: start;
+  }
+}
+
+@media (max-width: 48rem) {
+  .shell-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .register-page__intro {
+    margin-bottom: var(--space-6);
+  }
+
+  .register-page__title {
+    font-size: 2.125rem;
+  }
+
+  .register-form__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .register-field--full {
+    grid-column: auto;
+  }
+
+  .register-cta__button {
+    width: 100%;
+  }
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,5 +1,101 @@
-import { RoutePlaceholder } from "@/components/route-placeholder";
-
 export default function RegisterPage() {
-  return <RoutePlaceholder title="Register" path="/register" />;
+  return (
+    <section className="register-page">
+      <div className="register-page__intro">
+        <p className="register-page__eyebrow">Registration</p>
+        <h1 className="register-page__title">
+          Take your next step with intention.
+        </h1>
+        <p className="register-page__lede">
+          Share a few details so we can hold your place and carry you into the
+          payment step with clarity. This is a focused summit for people
+          navigating transition and looking for practical direction.
+        </p>
+      </div>
+
+      <div className="register-page__grid">
+        <form className="register-card register-form">
+          <div className="register-form__grid">
+            <label className="register-field">
+              <span>First name</span>
+              <input autoComplete="given-name" name="firstName" type="text" />
+            </label>
+
+            <label className="register-field">
+              <span>Last name</span>
+              <input autoComplete="family-name" name="lastName" type="text" />
+            </label>
+
+            <label className="register-field register-field--full">
+              <span>Email</span>
+              <input autoComplete="email" name="email" type="email" />
+            </label>
+
+            <label className="register-field">
+              <span>Phone</span>
+              <input autoComplete="tel" name="phone" type="tel" />
+            </label>
+
+            <label className="register-field">
+              <span>Organization / School / Team</span>
+              <input name="organization" type="text" />
+            </label>
+
+            <label className="register-field register-field--full">
+              <span>Role or affiliation</span>
+              <input name="role" type="text" />
+            </label>
+
+            <label className="register-field register-field--full">
+              <span>What are you hoping to get from the summit?</span>
+              <textarea name="notes" rows={5} />
+            </label>
+          </div>
+
+          <div className="register-cta">
+            <div className="register-cta__content">
+              <h2>Continue when you&apos;re ready</h2>
+              <p>
+                Payment is the next step. This page sets the expectation and
+                gives attendees a clear place to commit before checkout is
+                added.
+              </p>
+            </div>
+            <button className="register-cta__button" type="button">
+              Continue to Payment
+            </button>
+          </div>
+        </form>
+
+        <aside className="register-sidebar">
+          <section className="register-card register-card--support register-panel">
+            <h2>Summit snapshot</h2>
+            <p>
+              Settled on the Field is built for athletes, veterans, and
+              professionals navigating a meaningful transition with more
+              questions than certainty.
+            </p>
+            <ul>
+              <li>Focused speakers and practical conversations</li>
+              <li>Space to reflect, connect, and move forward</li>
+              <li>A calm structure built around clarity, not noise</li>
+            </ul>
+          </section>
+
+          <section className="register-card register-card--support register-panel">
+            <h2>What happens next</h2>
+            <ol>
+              <li>Complete your registration details.</li>
+              <li>Review the payment step.</li>
+              <li>Receive confirmation once checkout is live.</li>
+            </ol>
+            <p className="register-panel__note">
+              Questions or hesitation are normal. This step is here to make the
+              path feel clear before payment is introduced.
+            </p>
+          </section>
+        </aside>
+      </div>
+    </section>
+  );
 }


### PR DESCRIPTION
## Summary
Refined the /register page to align visually with Landing and Summit pages. Removed card-based styling in favor of section-based layout to match the existing design language and improve conversion flow continuity.

## Related Issue
Closes #26 

## Changes
- Flattened register layout from card-style panels to section-based structure
- Aligned heading scale and paragraph rhythm with existing pages
- Adjusted spacing and content width for consistency
- Normalized CTA styling to match primary actions across the site
- Improved mobile spacing and layout behavior

## Verification checklist
- [x] /register renders correctly on desktop
- [x] Visual parity with / and /summit confirmed
- [x] CTA appears consistent with other primary actions
- [x] Mobile layout stacks cleanly and CTA is full width
- [x] No regression in shared header/footer

## Notes
This change stays within UI scope. No backend logic, routing, or form handling was introduced.