### PR TITLE
Issue 2-2: Add registration form handling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -130,6 +130,25 @@ a {
   line-height: 1.5;
 }
 
+.register-status {
+  max-width: 40rem;
+  margin-top: var(--space-6);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.register-status__title {
+  margin: 0 0 0.5rem;
+  color: var(--color-primary);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.register-status__body {
+  margin: 0;
+  color: var(--color-accent);
+}
+
 .register-page__grid {
   display: grid;
   gap: var(--space-12);
@@ -140,6 +159,20 @@ a {
   gap: var(--space-6);
   padding-top: var(--space-6);
   border-top: 1px solid var(--color-border);
+}
+
+.register-form__required-note,
+.register-form__feedback {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.register-form__required-note {
+  color: var(--color-accent);
+}
+
+.register-form__feedback {
+  color: var(--color-primary);
 }
 
 .register-form__grid {
@@ -159,6 +192,10 @@ a {
   font-size: 0.95rem;
   font-weight: 600;
   line-height: 1.3;
+}
+
+.register-field__required {
+  color: var(--color-accent);
 }
 
 .register-field--full {
@@ -192,6 +229,17 @@ a {
 .register-field textarea:focus {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
+}
+
+.register-field input[aria-invalid="true"],
+.register-field textarea[aria-invalid="true"] {
+  border-color: var(--color-primary);
+}
+
+.register-field__error {
+  margin: 0;
+  color: var(--color-primary);
+  font-size: 0.9rem;
 }
 
 .register-cta {
@@ -241,6 +289,11 @@ a {
   font-weight: 600;
   line-height: 1.2;
   cursor: pointer;
+}
+
+.register-cta__button:disabled {
+  opacity: 1;
+  cursor: progress;
 }
 
 .register-sidebar {

--- a/app/register/actions.ts
+++ b/app/register/actions.ts
@@ -1,0 +1,39 @@
+'use server';
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import {
+  REGISTRATION_DRAFT_COOKIE,
+  buildRegistrationDraft,
+  normalizeRegistrationValues,
+  validateRegistrationValues,
+} from "./registration";
+import type { RegisterFormState } from "./types";
+
+export async function submitRegistration(
+  _prevState: RegisterFormState,
+  formData: FormData,
+): Promise<RegisterFormState> {
+  const values = normalizeRegistrationValues(formData);
+  const fieldErrors = validateRegistrationValues(values);
+
+  if (Object.keys(fieldErrors).length > 0) {
+    return {
+      formError: "Please correct the highlighted fields and try again.",
+      fieldErrors,
+    };
+  }
+
+  const cookieStore = await cookies();
+  const draft = buildRegistrationDraft(values);
+
+  cookieStore.set(REGISTRATION_DRAFT_COOKIE, encodeURIComponent(JSON.stringify(draft)), {
+    httpOnly: true,
+    maxAge: 60 * 60 * 24,
+    path: "/",
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+  });
+
+  redirect("/register?step=payment");
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,4 +1,21 @@
-export default function RegisterPage() {
+import { RegisterForm } from "./register-form";
+import { readRegistrationDraft } from "./registration";
+import { EMPTY_REGISTRATION_FORM_VALUES } from "./types";
+
+type RegisterPageProps = {
+  searchParams: Promise<{
+    step?: string | string[];
+  }>;
+};
+
+export default async function RegisterPage({
+  searchParams,
+}: RegisterPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const draft = await readRegistrationDraft();
+  const paymentReady =
+    resolvedSearchParams.step === "payment" && draft !== null;
+
   return (
     <section className="register-page">
       <div className="register-page__intro">
@@ -11,64 +28,26 @@ export default function RegisterPage() {
           payment step with clarity. This is a focused summit for people
           navigating transition and looking for practical direction.
         </p>
+
+        {paymentReady ? (
+          <div className="register-status register-status--success">
+            <p className="register-status__title">Registration details saved</p>
+            <p className="register-status__body">
+              {draft?.firstName} {draft?.lastName} is ready for the payment
+              handoff with {draft?.email}.
+            </p>
+          </div>
+        ) : null}
       </div>
 
       <div className="register-page__grid">
-        <form className="register-card register-form">
-          <div className="register-form__grid">
-            <label className="register-field">
-              <span>First name</span>
-              <input autoComplete="given-name" name="firstName" type="text" />
-            </label>
-
-            <label className="register-field">
-              <span>Last name</span>
-              <input autoComplete="family-name" name="lastName" type="text" />
-            </label>
-
-            <label className="register-field register-field--full">
-              <span>Email</span>
-              <input autoComplete="email" name="email" type="email" />
-            </label>
-
-            <label className="register-field">
-              <span>Phone</span>
-              <input autoComplete="tel" name="phone" type="tel" />
-            </label>
-
-            <label className="register-field">
-              <span>Organization / School / Team</span>
-              <input name="organization" type="text" />
-            </label>
-
-            <label className="register-field register-field--full">
-              <span>Role or affiliation</span>
-              <input name="role" type="text" />
-            </label>
-
-            <label className="register-field register-field--full">
-              <span>What are you hoping to get from the summit?</span>
-              <textarea name="notes" rows={5} />
-            </label>
-          </div>
-
-          <div className="register-cta">
-            <div className="register-cta__content">
-              <h2>Continue when you&apos;re ready</h2>
-              <p>
-                Payment is the next step. This page sets the expectation and
-                gives attendees a clear place to commit before checkout is
-                added.
-              </p>
-            </div>
-            <button className="register-cta__button" type="button">
-              Continue to Payment
-            </button>
-          </div>
-        </form>
+        <RegisterForm
+          defaultValues={draft ?? EMPTY_REGISTRATION_FORM_VALUES}
+          paymentReady={paymentReady}
+        />
 
         <aside className="register-sidebar">
-          <section className="register-card register-card--support register-panel">
+          <section className="register-panel">
             <h2>Summit snapshot</h2>
             <p>
               Settled on the Field is built for athletes, veterans, and
@@ -82,7 +61,7 @@ export default function RegisterPage() {
             </ul>
           </section>
 
-          <section className="register-card register-card--support register-panel">
+          <section className="register-panel">
             <h2>What happens next</h2>
             <ol>
               <li>Complete your registration details.</li>

--- a/app/register/register-form.tsx
+++ b/app/register/register-form.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useActionState, type InputHTMLAttributes } from "react";
+import { submitRegistration } from "./actions";
+import type {
+  RegisterFormState,
+  RegistrationFormValues,
+} from "./types";
+
+const INITIAL_STATE: RegisterFormState = {
+  fieldErrors: {},
+};
+
+type RegisterFormProps = {
+  defaultValues: RegistrationFormValues;
+  paymentReady: boolean;
+};
+
+type RegisterFieldProps = {
+  autoComplete?: string;
+  defaultValue: string;
+  error?: string;
+  inputMode?: InputHTMLAttributes<HTMLInputElement>["inputMode"];
+  label: string;
+  name: keyof RegistrationFormValues;
+  required?: boolean;
+  rows?: number;
+  type?: string;
+};
+
+function RegisterField({
+  autoComplete,
+  defaultValue,
+  error,
+  inputMode,
+  label,
+  name,
+  required = false,
+  rows,
+  type = "text",
+}: RegisterFieldProps) {
+  const errorId = `${name}-error`;
+  const describedBy = error ? errorId : undefined;
+
+  return (
+    <label
+      className={`register-field${rows ? " register-field--full" : ""}`}
+      htmlFor={name}
+    >
+      <span className="register-field__label">
+        {label}
+        {required ? (
+          <span aria-hidden="true" className="register-field__required">
+            {" "}
+            *
+          </span>
+        ) : null}
+      </span>
+
+      {rows ? (
+        <textarea
+          aria-describedby={describedBy}
+          aria-invalid={error ? "true" : undefined}
+          autoComplete={autoComplete}
+          defaultValue={defaultValue}
+          id={name}
+          name={name}
+          rows={rows}
+        />
+      ) : (
+        <input
+          aria-describedby={describedBy}
+          aria-invalid={error ? "true" : undefined}
+          autoComplete={autoComplete}
+          defaultValue={defaultValue}
+          id={name}
+          inputMode={inputMode}
+          name={name}
+          required={required}
+          type={type}
+        />
+      )}
+
+      {error ? (
+        <p className="register-field__error" id={errorId} role="alert">
+          {error}
+        </p>
+      ) : null}
+    </label>
+  );
+}
+
+export function RegisterForm({
+  defaultValues,
+  paymentReady,
+}: RegisterFormProps) {
+  const [state, formAction, pending] = useActionState(
+    submitRegistration,
+    INITIAL_STATE,
+  );
+
+  return (
+    <form action={formAction} className="register-form">
+      <p className="register-form__required-note">
+        Required fields are marked with *
+      </p>
+
+      {state.formError ? (
+        <p className="register-form__feedback" role="alert">
+          {state.formError}
+        </p>
+      ) : null}
+
+      <div className="register-form__grid">
+        <RegisterField
+          autoComplete="given-name"
+          defaultValue={defaultValues.firstName}
+          error={state.fieldErrors.firstName}
+          label="First name"
+          name="firstName"
+          required
+        />
+
+        <RegisterField
+          autoComplete="family-name"
+          defaultValue={defaultValues.lastName}
+          error={state.fieldErrors.lastName}
+          label="Last name"
+          name="lastName"
+          required
+        />
+
+        <RegisterField
+          autoComplete="email"
+          defaultValue={defaultValues.email}
+          error={state.fieldErrors.email}
+          inputMode="email"
+          label="Email"
+          name="email"
+          required
+          type="email"
+        />
+
+        <RegisterField
+          autoComplete="tel"
+          defaultValue={defaultValues.phone}
+          inputMode="tel"
+          label="Phone"
+          name="phone"
+          type="tel"
+        />
+
+        <RegisterField
+          defaultValue={defaultValues.organization}
+          label="Organization / School / Team"
+          name="organization"
+        />
+
+        <RegisterField
+          defaultValue={defaultValues.role}
+          label="Role or affiliation"
+          name="role"
+        />
+
+        <RegisterField
+          defaultValue={defaultValues.notes}
+          label="What are you hoping to get from the summit?"
+          name="notes"
+          rows={5}
+        />
+      </div>
+
+      <div className="register-cta">
+        <div className="register-cta__content">
+          <h2>
+            {paymentReady
+              ? "Your details are ready for payment"
+              : "Continue when you're ready"}
+          </h2>
+          <p>
+            {paymentReady
+              ? "Your registration draft is saved. Payment is still the next step, and this handoff is ready for the checkout work in the next issue."
+              : "Payment is the next step. This page now captures your details, validates the essentials, and prepares a clean handoff before checkout is added."}
+          </p>
+        </div>
+        <button className="register-cta__button" disabled={pending} type="submit">
+          {pending
+            ? "Saving your details..."
+            : paymentReady
+              ? "Update Saved Details"
+              : "Continue to Payment"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/register/registration.ts
+++ b/app/register/registration.ts
@@ -1,0 +1,127 @@
+import { cookies } from "next/headers";
+import {
+  EMPTY_REGISTRATION_FORM_VALUES,
+  type RegisterFormState,
+  type RegistrationDraft,
+  type RegistrationFormValues,
+} from "./types";
+
+export const REGISTRATION_DRAFT_COOKIE = "settled-registration-draft";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function getStringValue(formData: FormData, key: keyof RegistrationFormValues) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : "";
+}
+
+function normalizeSingleLine(value: string) {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function normalizeMultiline(value: string) {
+  return value
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n")
+    .trim();
+}
+
+function asRegistrationValues(
+  value: Partial<Record<keyof RegistrationFormValues, unknown>>,
+): RegistrationFormValues {
+  return {
+    firstName:
+      typeof value.firstName === "string"
+        ? normalizeSingleLine(value.firstName)
+        : "",
+    lastName:
+      typeof value.lastName === "string" ? normalizeSingleLine(value.lastName) : "",
+    email:
+      typeof value.email === "string"
+        ? normalizeSingleLine(value.email).toLowerCase()
+        : "",
+    phone:
+      typeof value.phone === "string" ? normalizeSingleLine(value.phone) : "",
+    organization:
+      typeof value.organization === "string"
+        ? normalizeSingleLine(value.organization)
+        : "",
+    role: typeof value.role === "string" ? normalizeSingleLine(value.role) : "",
+    notes:
+      typeof value.notes === "string" ? normalizeMultiline(value.notes) : "",
+  };
+}
+
+export function normalizeRegistrationValues(
+  formData: FormData,
+): RegistrationFormValues {
+  return asRegistrationValues({
+    firstName: getStringValue(formData, "firstName"),
+    lastName: getStringValue(formData, "lastName"),
+    email: getStringValue(formData, "email"),
+    phone: getStringValue(formData, "phone"),
+    organization: getStringValue(formData, "organization"),
+    role: getStringValue(formData, "role"),
+    notes: getStringValue(formData, "notes"),
+  });
+}
+
+export function validateRegistrationValues(
+  values: RegistrationFormValues,
+): RegisterFormState["fieldErrors"] {
+  const fieldErrors: RegisterFormState["fieldErrors"] = {};
+
+  if (!values.firstName) {
+    fieldErrors.firstName = "Enter your first name.";
+  }
+
+  if (!values.lastName) {
+    fieldErrors.lastName = "Enter your last name.";
+  }
+
+  if (!values.email) {
+    fieldErrors.email = "Enter your email address.";
+  } else if (!EMAIL_PATTERN.test(values.email)) {
+    fieldErrors.email = "Enter a valid email address.";
+  }
+
+  return fieldErrors;
+}
+
+export function buildRegistrationDraft(
+  values: RegistrationFormValues,
+): RegistrationDraft {
+  return {
+    ...values,
+    submittedAt: new Date().toISOString(),
+  };
+}
+
+export async function readRegistrationDraft() {
+  const cookieStore = await cookies();
+  const draftCookie = cookieStore.get(REGISTRATION_DRAFT_COOKIE);
+
+  if (!draftCookie) {
+    return null;
+  }
+
+  try {
+    const parsedDraft = JSON.parse(
+      decodeURIComponent(draftCookie.value),
+    ) as Partial<RegistrationDraft>;
+
+    if (typeof parsedDraft.submittedAt !== "string") {
+      return null;
+    }
+
+    return {
+      ...EMPTY_REGISTRATION_FORM_VALUES,
+      ...asRegistrationValues(parsedDraft),
+      submittedAt: parsedDraft.submittedAt,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/app/register/types.ts
+++ b/app/register/types.ts
@@ -1,0 +1,30 @@
+export type RegistrationFormValues = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  organization: string;
+  role: string;
+  notes: string;
+};
+
+export type RegistrationDraft = RegistrationFormValues & {
+  submittedAt: string;
+};
+
+export type RegisterFieldName = keyof RegistrationFormValues;
+
+export type RegisterFormState = {
+  formError?: string;
+  fieldErrors: Partial<Record<RegisterFieldName, string>>;
+};
+
+export const EMPTY_REGISTRATION_FORM_VALUES: RegistrationFormValues = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  phone: "",
+  organization: "",
+  role: "",
+  notes: "",
+};


### PR DESCRIPTION
## Summary
Added the first behavior layer to the registration flow using a Next.js server action. The form now validates required fields, normalizes email input, stores a short-lived registration draft in an HTTP-only cookie, and returns the user to a payment-ready handoff state on `/register`.

## Related Issue
Closes #27 

## Changes
- Added server action for `/register` submission handling
- Enforced required first name, last name, and email
- Added basic server-side email normalization and validation
- Stored a short-lived registration draft in an HTTP-only cookie
- Added payment-ready handoff state on `/register?step=payment`
- Added inline error handling and pending state for the form

## Verification checklist
- [x] `/register` loads cleanly
- [x] Valid submission reaches payment-ready state
- [x] Missing required fields show inline errors
- [x] Invalid email shows calm failure messaging
- [x] Refresh on payment-ready state behaves correctly
- [x] Saved details can be edited and resubmitted
- [x] `npm run lint` passes
- [x] `npm run build` passes

## Notes
This stays intentionally narrow. No Stripe integration, no database persistence, and no permanent registration record were added in this issue. The cookie-based draft is a lightweight bridge into the payment work in Issue 2-3.