### PR TITLE
Issue 2-3: Scaffold Stripe checkout entry point

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
 # Database
 DATABASE_URL=postgres://USER:PASSWORD@HOST:PORT/DATABASE
 
-# Stripe (placeholders for future use)
-STRIPE_SECRET_KEY=sk_test_placeholder
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
+# Stripe Checkout scaffold
+STRIPE_SECRET_KEY=
+STRIPE_PRICE_ID=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import {
+  buildRegistrationDraft,
+  REGISTRATION_DRAFT_COOKIE,
+  getRegistrationDraftCookieOptions,
+  hasCheckoutReadyDraft,
+  normalizeRegistrationValues,
+  readRegistrationDraft,
+  serializeRegistrationDraft,
+} from "@/app/register/registration";
+import { EMPTY_REGISTRATION_FORM_VALUES } from "@/app/register/types";
+import { getStripeCheckoutConfig, buildStripeCheckoutSessionPayload } from "@/lib/stripe-checkout";
+
+function redirectToRegister(request: Request, search: Record<string, string>) {
+  const url = new URL("/register", request.url);
+
+  for (const [key, value] of Object.entries(search)) {
+    url.searchParams.set(key, value);
+  }
+
+  return NextResponse.redirect(url, 303);
+}
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const submittedRegistrationFields = Object.keys(
+    EMPTY_REGISTRATION_FORM_VALUES,
+  ).some((fieldName) => formData.has(fieldName));
+  const submittedValues = normalizeRegistrationValues(formData);
+  const submittedDraft = hasCheckoutReadyDraft(submittedValues)
+    ? buildRegistrationDraft(submittedValues)
+    : null;
+
+  if (submittedRegistrationFields && !submittedDraft) {
+    return redirectToRegister(request, {
+      error: "draft",
+      step: "payment",
+    });
+  }
+
+  const existingDraft = await readRegistrationDraft();
+  const draft = submittedDraft ?? existingDraft;
+
+  if (!draft || !hasCheckoutReadyDraft(draft)) {
+    return redirectToRegister(request, {
+      error: "draft",
+      step: "payment",
+    });
+  }
+
+  const stripeConfig = getStripeCheckoutConfig();
+
+  if (!stripeConfig) {
+    const response = redirectToRegister(request, {
+      mode: "stub",
+      step: "payment",
+    });
+
+    if (submittedDraft) {
+      response.cookies.set(
+        REGISTRATION_DRAFT_COOKIE,
+        serializeRegistrationDraft(submittedDraft),
+        getRegistrationDraftCookieOptions(),
+      );
+    }
+
+    return response;
+  }
+
+  const sessionPayload = buildStripeCheckoutSessionPayload(draft, stripeConfig);
+  void sessionPayload;
+  // Stripe session creation is intentionally deferred until real credentials
+  // and the SDK are introduced in a later issue.
+
+  const response = redirectToRegister(request, {
+    mode: "stripe-ready",
+    step: "payment",
+  });
+
+  if (submittedDraft) {
+    response.cookies.set(
+      REGISTRATION_DRAFT_COOKIE,
+      serializeRegistrationDraft(submittedDraft),
+      getRegistrationDraftCookieOptions(),
+    );
+  }
+
+  return response;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -149,6 +149,11 @@ a {
   color: var(--color-accent);
 }
 
+.register-status--error .register-status__title,
+.register-status--error .register-status__body {
+  color: var(--color-primary);
+}
+
 .register-page__grid {
   display: grid;
   gap: var(--space-12);

--- a/app/register/actions.ts
+++ b/app/register/actions.ts
@@ -1,12 +1,11 @@
 'use server';
 
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import {
-  REGISTRATION_DRAFT_COOKIE,
   buildRegistrationDraft,
   normalizeRegistrationValues,
   validateRegistrationValues,
+  writeRegistrationDraft,
 } from "./registration";
 import type { RegisterFormState } from "./types";
 
@@ -24,16 +23,8 @@ export async function submitRegistration(
     };
   }
 
-  const cookieStore = await cookies();
   const draft = buildRegistrationDraft(values);
-
-  cookieStore.set(REGISTRATION_DRAFT_COOKIE, encodeURIComponent(JSON.stringify(draft)), {
-    httpOnly: true,
-    maxAge: 60 * 60 * 24,
-    path: "/",
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-  });
+  await writeRegistrationDraft(draft);
 
   redirect("/register?step=payment");
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -2,8 +2,14 @@ import { RegisterForm } from "./register-form";
 import { readRegistrationDraft } from "./registration";
 import { EMPTY_REGISTRATION_FORM_VALUES } from "./types";
 
+function getSearchParamValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
 type RegisterPageProps = {
   searchParams: Promise<{
+    error?: string | string[];
+    mode?: string | string[];
     step?: string | string[];
   }>;
 };
@@ -13,8 +19,10 @@ export default async function RegisterPage({
 }: RegisterPageProps) {
   const resolvedSearchParams = await searchParams;
   const draft = await readRegistrationDraft();
-  const paymentReady =
-    resolvedSearchParams.step === "payment" && draft !== null;
+  const step = getSearchParamValue(resolvedSearchParams.step);
+  const mode = getSearchParamValue(resolvedSearchParams.mode);
+  const error = getSearchParamValue(resolvedSearchParams.error);
+  const paymentReady = step === "payment" && draft !== null;
 
   return (
     <section className="register-page">
@@ -29,12 +37,47 @@ export default async function RegisterPage({
           navigating transition and looking for practical direction.
         </p>
 
+        {error === "draft" ? (
+          <div className="register-status register-status--error">
+            <p className="register-status__title">
+              Save your registration details before payment
+            </p>
+            <p className="register-status__body">
+              A valid registration draft was not available for checkout. Review
+              your details and continue again.
+            </p>
+          </div>
+        ) : null}
+
         {paymentReady ? (
           <div className="register-status register-status--success">
             <p className="register-status__title">Registration details saved</p>
             <p className="register-status__body">
               {draft?.firstName} {draft?.lastName} is ready for the payment
               handoff with {draft?.email}.
+            </p>
+          </div>
+        ) : null}
+
+        {mode === "stub" ? (
+          <div className="register-status">
+            <p className="register-status__title">Checkout stub mode</p>
+            <p className="register-status__body">
+              Stripe checkout is not live in this environment yet. Your payment
+              handoff is wired and ready for keys to be added later.
+            </p>
+          </div>
+        ) : null}
+
+        {mode === "stripe-ready" ? (
+          <div className="register-status">
+            <p className="register-status__title">
+              Stripe configuration detected
+            </p>
+            <p className="register-status__body">
+              Checkout session scaffolding is in place. The final Stripe API
+              call can be added with minimal change once live integration work
+              begins.
             </p>
           </div>
         ) : null}

--- a/app/register/register-form.tsx
+++ b/app/register/register-form.tsx
@@ -179,16 +179,20 @@ export function RegisterForm({
           </h2>
           <p>
             {paymentReady
-              ? "Your registration draft is saved. Payment is still the next step, and this handoff is ready for the checkout work in the next issue."
+              ? "Your registration draft is saved. Continue to payment to use the new checkout entry point, or adjust the form first and continue when it looks right."
               : "Payment is the next step. This page now captures your details, validates the essentials, and prepares a clean handoff before checkout is added."}
           </p>
         </div>
-        <button className="register-cta__button" disabled={pending} type="submit">
+        <button
+          className="register-cta__button"
+          disabled={paymentReady ? false : pending}
+          formAction={paymentReady ? "/api/checkout" : undefined}
+          formMethod={paymentReady ? "post" : undefined}
+          type="submit"
+        >
           {pending
             ? "Saving your details..."
-            : paymentReady
-              ? "Update Saved Details"
-              : "Continue to Payment"}
+            : "Continue to Payment"}
         </button>
       </div>
     </form>

--- a/app/register/registration.ts
+++ b/app/register/registration.ts
@@ -7,6 +7,7 @@ import {
 } from "./types";
 
 export const REGISTRATION_DRAFT_COOKIE = "settled-registration-draft";
+export const REGISTRATION_DRAFT_MAX_AGE = 60 * 60 * 24;
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -97,6 +98,34 @@ export function buildRegistrationDraft(
     ...values,
     submittedAt: new Date().toISOString(),
   };
+}
+
+export function hasCheckoutReadyDraft(values: RegistrationFormValues) {
+  return Object.keys(validateRegistrationValues(values)).length === 0;
+}
+
+export function serializeRegistrationDraft(draft: RegistrationDraft) {
+  return encodeURIComponent(JSON.stringify(draft));
+}
+
+export function getRegistrationDraftCookieOptions() {
+  return {
+    httpOnly: true,
+    maxAge: REGISTRATION_DRAFT_MAX_AGE,
+    path: "/",
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+  };
+}
+
+export async function writeRegistrationDraft(draft: RegistrationDraft) {
+  const cookieStore = await cookies();
+
+  cookieStore.set(
+    REGISTRATION_DRAFT_COOKIE,
+    serializeRegistrationDraft(draft),
+    getRegistrationDraftCookieOptions(),
+  );
 }
 
 export async function readRegistrationDraft() {

--- a/lib/stripe-checkout.ts
+++ b/lib/stripe-checkout.ts
@@ -1,0 +1,64 @@
+import type { RegistrationDraft } from "@/app/register/types";
+
+type StripeCheckoutConfig = {
+  appUrl: string;
+  priceId: string;
+  secretKey: string;
+};
+
+type StripeCheckoutSessionPayload = {
+  cancel_url: string;
+  customer_email: string;
+  line_items: Array<{
+    price: string;
+    quantity: number;
+  }>;
+  metadata: Record<string, string>;
+  mode: "payment";
+  success_url: string;
+};
+
+function normalizeAppUrl(value: string) {
+  return value.trim().replace(/\/+$/, "");
+}
+
+export function getStripeCheckoutConfig(): StripeCheckoutConfig | null {
+  const secretKey = process.env.STRIPE_SECRET_KEY?.trim();
+  const priceId = process.env.STRIPE_PRICE_ID?.trim();
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim();
+
+  if (!secretKey || !priceId || !appUrl) {
+    return null;
+  }
+
+  return {
+    appUrl: normalizeAppUrl(appUrl),
+    priceId,
+    secretKey,
+  };
+}
+
+export function buildStripeCheckoutSessionPayload(
+  draft: RegistrationDraft,
+  config: StripeCheckoutConfig,
+): StripeCheckoutSessionPayload {
+  return {
+    cancel_url: `${config.appUrl}/register?step=payment&mode=cancelled`,
+    customer_email: draft.email,
+    line_items: [
+      {
+        price: config.priceId,
+        quantity: 1,
+      },
+    ],
+    metadata: {
+      attendeeEmail: draft.email,
+      attendeeName: `${draft.firstName} ${draft.lastName}`.trim(),
+      organization: draft.organization,
+      role: draft.role,
+      submittedAt: draft.submittedAt,
+    },
+    mode: "payment",
+    success_url: `${config.appUrl}/confirmation?mode=checkout`,
+  };
+}


### PR DESCRIPTION
## Summary
Scaffolded the Stripe Checkout handoff around the existing registration draft flow. Added a server-side checkout entry point, established Stripe env/config shape, and introduced a safe stub mode when Stripe is not configured.

## Related Issue
Closes #28 

## Changes
- Added server-side `/api/checkout` entry point
- Reused and revalidated the registration draft before payment handoff
- Added contained Stripe checkout config/payload helper in `lib/stripe-checkout.ts`
- Updated payment-ready CTA to continue into checkout flow
- Added controlled stub mode when Stripe keys are missing
- Updated `.env.example` with Stripe-related config placeholders

## Verification checklist
- [ ] Valid registration reaches payment-ready state
- [ ] Continue to Payment reaches controlled stub mode
- [ ] Stub messaging clearly indicates checkout is not live yet
- [ ] No false success state is shown
- [ ] Updated registration details carry forward correctly
- [ ] `npm run lint` passes
- [ ] `npm run build` passes

## Notes
This is intentionally a scaffold only. No live Stripe API call, webhook handling, durable payment persistence, or final confirmation logic was added in this issue.