### PR TITLE
Issue 2-4: Build public confirmation page

### DIFF
--- a/app/confirmation/page.tsx
+++ b/app/confirmation/page.tsx
@@ -1,5 +1,88 @@
-import { RoutePlaceholder } from "@/components/route-placeholder";
+import Link from "next/link";
 
-export default function ConfirmationPage() {
-  return <RoutePlaceholder title="Confirmation" path="/confirmation" />;
+function getSearchParamValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+type ConfirmationPageProps = {
+  searchParams: Promise<{
+    mode?: string | string[];
+  }>;
+};
+
+export default async function ConfirmationPage({
+  searchParams,
+}: ConfirmationPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const mode = getSearchParamValue(resolvedSearchParams.mode);
+  const fromCheckout = mode === "checkout";
+
+  return (
+    <section className="confirmation-page">
+      <div className="confirmation-page__intro">
+        <p className="confirmation-page__eyebrow">Confirmation</p>
+        <h1 className="confirmation-page__title">
+          Your next step is in place.
+        </h1>
+        <p className="confirmation-page__lede">
+          {fromCheckout
+            ? "Your checkout flow has reached its confirmation destination. Final live payment verification will be connected when Stripe is fully enabled."
+            : "This page is the public confirmation destination for the summit flow. It is ready for the live checkout return, while staying clear that payment confirmation is not active in this environment."}
+        </p>
+
+        <div className="confirmation-status">
+          <p className="confirmation-status__title">
+            {fromCheckout
+              ? "Checkout return structure is ready"
+              : "Controlled confirmation placeholder"}
+          </p>
+          <p className="confirmation-status__body">
+            {fromCheckout
+              ? "You are seeing the live-ready confirmation structure used after checkout returns. This confirms the route and page shape, not a verified payment result."
+              : "Stripe is not live yet, so this page does not claim a completed payment. It exists to complete the public flow shape and support the real return step later with minimal change."}
+          </p>
+        </div>
+      </div>
+
+      <div className="confirmation-page__grid">
+        <section className="confirmation-section">
+          <h2>What happens next</h2>
+          <ol className="confirmation-list">
+            <li>Your registration and checkout path can end here cleanly.</li>
+            <li>Summit details and follow-up instructions can be added here later.</li>
+            <li>Live payment confirmation can plug into this structure once Stripe is enabled.</li>
+          </ol>
+        </section>
+
+        <section className="confirmation-section">
+          <h2>What this page means today</h2>
+          <p>
+            This is a calm handoff point for the current demo and stub flow. It
+            shows the intended post-commit destination without overstating what
+            has happened behind the scenes.
+          </p>
+          <p className="confirmation-section__note">
+            Details, attendance instructions, or payment-specific messaging can
+            be layered in later without replacing the route.
+          </p>
+        </section>
+      </div>
+
+      <section className="confirmation-actions">
+        <h2>Keep moving</h2>
+        <p>
+          If you want to review the event again or start over from the public
+          site, use either path below.
+        </p>
+        <div className="confirmation-actions__links">
+          <Link className="confirmation-actions__primary" href="/summit">
+            Back to Summit
+          </Link>
+          <Link className="confirmation-actions__secondary" href="/">
+            Return Home
+          </Link>
+        </div>
+      </section>
+    </section>
+  );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -323,9 +323,132 @@ a {
   padding-top: var(--space-6);
 }
 
+.confirmation-page {
+  padding-top: var(--space-8);
+  padding-bottom: var(--space-8);
+}
+
+.confirmation-page__intro {
+  max-width: 42rem;
+  margin-bottom: var(--space-8);
+}
+
+.confirmation-page__eyebrow {
+  margin: 0 0 var(--space-4);
+  color: var(--color-accent);
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.confirmation-page__title {
+  margin: 0 0 var(--space-4);
+  color: var(--color-primary);
+  max-width: 34rem;
+  font-size: 2.5rem;
+  line-height: 1.1;
+}
+
+.confirmation-page__lede {
+  max-width: 40rem;
+  margin: 0;
+  color: var(--color-accent);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.confirmation-status,
+.confirmation-section,
+.confirmation-actions {
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.confirmation-status {
+  max-width: 40rem;
+  margin-top: var(--space-6);
+}
+
+.confirmation-status__title {
+  margin: 0 0 0.5rem;
+  color: var(--color-primary);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.confirmation-status__body,
+.confirmation-section p,
+.confirmation-section li,
+.confirmation-actions p {
+  color: var(--color-accent);
+  line-height: 1.5;
+}
+
+.confirmation-status__body,
+.confirmation-section p,
+.confirmation-section ol,
+.confirmation-actions p {
+  margin: 0;
+}
+
+.confirmation-page__grid {
+  display: grid;
+  gap: var(--space-8);
+  margin-bottom: var(--space-8);
+}
+
+.confirmation-section h2,
+.confirmation-actions h2 {
+  margin: 0 0 0.75rem;
+  color: var(--color-primary);
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.confirmation-list {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+}
+
+.confirmation-section__note {
+  padding-top: var(--space-6);
+}
+
+.confirmation-actions__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  padding-top: var(--space-6);
+}
+
+.confirmation-actions__primary,
+.confirmation-actions__secondary {
+  display: inline-block;
+  min-height: 3.25rem;
+  padding: var(--space-4) var(--space-6);
+  line-height: 1.2;
+}
+
+.confirmation-actions__primary {
+  background: var(--color-primary);
+  color: var(--color-background);
+}
+
+.confirmation-actions__secondary {
+  background: var(--color-background);
+  color: var(--color-primary);
+}
+
 @media (min-width: 64rem) {
   .register-page__grid {
     grid-template-columns: minmax(0, 1.7fr) minmax(18rem, 1fr);
+    align-items: start;
+  }
+
+  .confirmation-page__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: start;
   }
 }
@@ -340,7 +463,15 @@ a {
     margin-bottom: var(--space-6);
   }
 
+  .confirmation-page__intro {
+    margin-bottom: var(--space-6);
+  }
+
   .register-page__title {
+    font-size: 2.125rem;
+  }
+
+  .confirmation-page__title {
     font-size: 2.125rem;
   }
 
@@ -353,6 +484,11 @@ a {
   }
 
   .register-cta__button {
+    width: 100%;
+  }
+
+  .confirmation-actions__primary,
+  .confirmation-actions__secondary {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
Added a real public confirmation page and replaced the placeholder route. The page supports both a default placeholder state and a checkout-return mode, without implying verified payment success.

## Related Issue
Closes #29 

## Changes
- Created `/confirmation` route
- Added support for `?mode=checkout` state
- Implemented calm, trustworthy confirmation messaging
- Matched visual language with Landing, Summit, and Register pages
- Added responsive confirmation-specific styling

## Verification checklist
- [ ] `/confirmation` renders correctly
- [ ] `/confirmation?mode=checkout` renders correctly
- [ ] Messaging does not imply successful payment
- [ ] Visual consistency matches public pages
- [ ] Mobile layout is clean
- [ ] `npm run lint` passes
- [ ] `npm run build` passes

## Notes
This is a UI-only confirmation scaffold. No payment verification, webhook handling, or persistence was added. The route is designed to support real Stripe return flow in a future issue.