### PR TITLE
Issue 2-5: Harden duplicate and spam protection

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -166,6 +166,18 @@ a {
   border-top: 1px solid var(--color-border);
 }
 
+.register-honeypot {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .register-form__required-note,
 .register-form__feedback {
   margin: 0;

--- a/app/register/actions.ts
+++ b/app/register/actions.ts
@@ -1,8 +1,10 @@
 'use server';
 
 import { redirect } from "next/navigation";
+import { reserveRegistrationEmail } from "@/lib/registration-email-store";
 import {
   buildRegistrationDraft,
+  isHoneypotSubmission,
   normalizeRegistrationValues,
   validateRegistrationValues,
   writeRegistrationDraft,
@@ -13,6 +15,14 @@ export async function submitRegistration(
   _prevState: RegisterFormState,
   formData: FormData,
 ): Promise<RegisterFormState> {
+  if (isHoneypotSubmission(formData)) {
+    return {
+      formError:
+        "We couldn't process that submission. Please review your details and try again.",
+      fieldErrors: {},
+    };
+  }
+
   const values = normalizeRegistrationValues(formData);
   const fieldErrors = validateRegistrationValues(values);
 
@@ -20,6 +30,29 @@ export async function submitRegistration(
     return {
       formError: "Please correct the highlighted fields and try again.",
       fieldErrors,
+    };
+  }
+
+  try {
+    const duplicateStatus = await reserveRegistrationEmail(values.email);
+
+    if (duplicateStatus === "duplicate") {
+      return {
+        formError:
+          "We already have registration details for this email address.",
+        fieldErrors: {
+          email:
+            "This email address has already been submitted for the summit.",
+        },
+      };
+    }
+  } catch (error) {
+    console.error("Unable to reserve registration email", error);
+
+    return {
+      formError:
+        "We couldn't save your registration right now. Please try again.",
+      fieldErrors: {},
     };
   }
 

--- a/app/register/register-form.tsx
+++ b/app/register/register-form.tsx
@@ -6,6 +6,7 @@ import type {
   RegisterFormState,
   RegistrationFormValues,
 } from "./types";
+import { REGISTRATION_HONEYPOT_FIELD } from "./types";
 
 const INITIAL_STATE: RegisterFormState = {
   fieldErrors: {},
@@ -101,6 +102,22 @@ export function RegisterForm({
 
   return (
     <form action={formAction} className="register-form">
+      <div
+        aria-hidden="true"
+        className="register-honeypot"
+      >
+        <label htmlFor={REGISTRATION_HONEYPOT_FIELD}>
+          Leave this field empty
+        </label>
+        <input
+          autoComplete="off"
+          id={REGISTRATION_HONEYPOT_FIELD}
+          name={REGISTRATION_HONEYPOT_FIELD}
+          tabIndex={-1}
+          type="text"
+        />
+      </div>
+
       <p className="register-form__required-note">
         Required fields are marked with *
       </p>

--- a/app/register/registration.ts
+++ b/app/register/registration.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers";
 import {
   EMPTY_REGISTRATION_FORM_VALUES,
+  REGISTRATION_HONEYPOT_FIELD,
   type RegisterFormState,
   type RegistrationDraft,
   type RegistrationFormValues,
@@ -89,6 +90,12 @@ export function validateRegistrationValues(
   }
 
   return fieldErrors;
+}
+
+export function isHoneypotSubmission(formData: FormData) {
+  const honeypotValue = formData.get(REGISTRATION_HONEYPOT_FIELD);
+
+  return typeof honeypotValue === "string" && honeypotValue.trim().length > 0;
 }
 
 export function buildRegistrationDraft(

--- a/app/register/types.ts
+++ b/app/register/types.ts
@@ -19,6 +19,9 @@ export type RegisterFormState = {
   fieldErrors: Partial<Record<RegisterFieldName, string>>;
 };
 
+export type DuplicateRegistrationStatus = "created" | "duplicate";
+export const REGISTRATION_HONEYPOT_FIELD = "website";
+
 export const EMPTY_REGISTRATION_FORM_VALUES: RegistrationFormValues = {
   firstName: "",
   lastName: "",

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,11 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs" || !process.env.DATABASE_URL) {
+    return;
+  }
+
+  const { initializeRegistrationEmailStore } = await import(
+    "@/lib/registration-email-store"
+  );
+
+  await initializeRegistrationEmailStore();
+}

--- a/lib/registration-email-store.ts
+++ b/lib/registration-email-store.ts
@@ -1,0 +1,37 @@
+import { getDb } from "@/lib/db";
+import type { DuplicateRegistrationStatus } from "@/app/register/types";
+
+const REGISTRATION_EMAILS_TABLE = "registration_emails";
+let registrationEmailsTablePromise: Promise<void> | null = null;
+
+export async function initializeRegistrationEmailStore() {
+  if (!registrationEmailsTablePromise) {
+    registrationEmailsTablePromise = getDb()
+      .query(
+        `CREATE TABLE IF NOT EXISTS ${REGISTRATION_EMAILS_TABLE} (
+          normalized_email TEXT PRIMARY KEY,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )`,
+      )
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        registrationEmailsTablePromise = null;
+        throw error;
+      });
+  }
+
+  await registrationEmailsTablePromise;
+}
+
+export async function reserveRegistrationEmail(
+  email: string,
+): Promise<DuplicateRegistrationStatus> {
+  const result = await getDb().query(
+    `INSERT INTO ${REGISTRATION_EMAILS_TABLE} (normalized_email)
+     VALUES ($1)
+     ON CONFLICT (normalized_email) DO NOTHING`,
+    [email],
+  );
+
+  return result.rowCount === 1 ? "created" : "duplicate";
+}


### PR DESCRIPTION
## Summary
Added duplicate email protection and basic spam blocking to the registration flow, then hardened the implementation by moving `registration_emails` table creation out of the live submit path and into server startup.

## Related Issue
Closes #30 

## Changes
- Added hidden honeypot field to registration form
- Implemented server-side honeypot validation
- Normalized email input for duplicate detection
- Added DB-backed duplicate protection using `registration_emails`
- Moved `registration_emails` table initialization to server startup
- Removed request-time DDL from the registration submit path
- Preserved existing draft-cookie payment handoff for valid submissions

## Verification checklist
- [ ] Unique email submission succeeds
- [ ] Duplicate email submission is blocked cleanly
- [ ] Honeypot submission is blocked safely
- [ ] `registration_emails` exists before first registration request
- [ ] No request-time table creation occurs during submit
- [ ] `npm run lint` passes
- [ ] `npm run build` passes

## Notes
Duplicate protection remains intentionally scoped to normalized email only for MVP. Spam protection remains lightweight via honeypot. No advanced fraud detection, rate limiting, or payment-flow changes were introduced.