### PR TITLE
Issue 2-6: Add registration success redirect step

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -453,9 +453,136 @@ a {
   color: var(--color-primary);
 }
 
+.register-success-page {
+  padding-top: var(--space-8);
+  padding-bottom: var(--space-8);
+}
+
+.register-success-page__intro {
+  max-width: 42rem;
+  margin-bottom: var(--space-8);
+}
+
+.register-success-page__eyebrow {
+  margin: 0 0 var(--space-4);
+  color: var(--color-accent);
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.register-success-page__title {
+  margin: 0 0 var(--space-4);
+  color: var(--color-primary);
+  max-width: 34rem;
+  font-size: 2.5rem;
+  line-height: 1.1;
+}
+
+.register-success-page__lede {
+  max-width: 40rem;
+  margin: 0;
+  color: var(--color-accent);
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.register-success-page__grid {
+  display: grid;
+  gap: var(--space-8);
+  margin-bottom: var(--space-8);
+}
+
+.register-success-section,
+.register-success-actions {
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.register-success-section h2,
+.register-success-actions h2 {
+  margin: 0 0 0.75rem;
+  color: var(--color-primary);
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.register-success-section p,
+.register-success-section li,
+.register-success-actions p {
+  color: var(--color-accent);
+  line-height: 1.5;
+}
+
+.register-success-section p,
+.register-success-section ol,
+.register-success-actions p {
+  margin: 0;
+}
+
+.register-success-list {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.25rem;
+}
+
+.register-success-section__note {
+  padding-top: var(--space-6);
+}
+
+.register-success-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--space-6);
+}
+
+.register-success-actions__content {
+  max-width: 32rem;
+}
+
+.register-success-actions__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+
+.register-success-actions__links form {
+  margin: 0;
+}
+
+.register-success-actions__primary,
+.register-success-actions__secondary {
+  display: inline-block;
+  border: 0;
+  min-height: 3.5rem;
+  padding: var(--space-4) var(--space-6);
+  font: inherit;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.register-success-actions__primary {
+  background: var(--color-primary);
+  color: var(--color-background);
+  cursor: pointer;
+}
+
+.register-success-actions__secondary {
+  background: var(--color-background);
+  color: var(--color-primary);
+}
+
 @media (min-width: 64rem) {
   .register-page__grid {
     grid-template-columns: minmax(0, 1.7fr) minmax(18rem, 1fr);
+    align-items: start;
+  }
+
+  .register-success-page__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: start;
   }
 
@@ -479,7 +606,15 @@ a {
     margin-bottom: var(--space-6);
   }
 
+  .register-success-page__intro {
+    margin-bottom: var(--space-6);
+  }
+
   .register-page__title {
+    font-size: 2.125rem;
+  }
+
+  .register-success-page__title {
     font-size: 2.125rem;
   }
 
@@ -501,6 +636,16 @@ a {
 
   .confirmation-actions__primary,
   .confirmation-actions__secondary {
+    width: 100%;
+  }
+
+  .register-success-actions__links {
+    width: 100%;
+  }
+
+  .register-success-actions__links form,
+  .register-success-actions__primary,
+  .register-success-actions__secondary {
     width: 100%;
   }
 }

--- a/app/register/actions.ts
+++ b/app/register/actions.ts
@@ -59,5 +59,5 @@ export async function submitRegistration(
   const draft = buildRegistrationDraft(values);
   await writeRegistrationDraft(draft);
 
-  redirect("/register?step=payment");
+  redirect("/register/success");
 }

--- a/app/register/success/page.tsx
+++ b/app/register/success/page.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { readRegistrationDraft } from "../registration";
+
+export default async function RegisterSuccessPage() {
+  const draft = await readRegistrationDraft();
+
+  if (!draft) {
+    redirect("/register?error=draft");
+  }
+
+  return (
+    <section className="register-success-page">
+      <div className="register-success-page__intro">
+        <p className="register-success-page__eyebrow">Registration</p>
+        <h1 className="register-success-page__title">
+          Your details are in place.
+        </h1>
+        <p className="register-success-page__lede">
+          {draft.firstName} {draft.lastName}, we have your registration details
+          and the next step is payment. This page is here to make the handoff
+          feel clear before checkout begins.
+        </p>
+      </div>
+
+      <div className="register-success-page__grid">
+        <section className="register-success-section">
+          <h2>What happens next</h2>
+          <ol className="register-success-list">
+            <li>Your registration details stay ready for checkout.</li>
+            <li>Payment is the next step in the summit flow.</li>
+            <li>Confirmation comes after checkout is complete.</li>
+          </ol>
+        </section>
+
+        <section className="register-success-section">
+          <h2>Registration summary</h2>
+          <p>{draft.email}</p>
+          {draft.organization ? <p>{draft.organization}</p> : null}
+          {draft.role ? <p>{draft.role}</p> : null}
+          <p className="register-success-section__note">
+            Need to adjust something before payment? Return to registration and
+            update your details.
+          </p>
+        </section>
+      </div>
+
+      <section className="register-success-actions">
+        <div className="register-success-actions__content">
+          <h2>Continue when you&apos;re ready</h2>
+          <p>
+            Stripe is still operating through the current scaffold, so this
+            continues into the existing payment-ready path without implying
+            completed payment.
+          </p>
+        </div>
+        <div className="register-success-actions__links">
+          <form action="/api/checkout" method="post">
+            <button className="register-success-actions__primary" type="submit">
+              Continue to Payment
+            </button>
+          </form>
+          <Link className="register-success-actions__secondary" href="/register">
+            Edit Registration
+          </Link>
+        </div>
+      </section>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
Added a dedicated post-submit transition step for successful registration submissions. Valid submissions now redirect to `/register/success`, where the user is told their details were received and payment is the next step.

## Related Issue
Closes #31 

## Changes
- Redirected successful registration submissions to `/register/success`
- Added a dedicated transition page for post-submit success state
- Kept messaging clear that payment is still the next step
- Preserved the existing `/api/checkout` handoff
- Kept invalid, duplicate, and spam-like submissions in the `/register` form flow

## Verification checklist
- [x] Valid unique submission redirects to `/register/success`
- [x] `/register/success` renders clear next-step messaging
- [x] Continue to Payment reaches the existing checkout scaffold
- [x] Duplicate submission stays on `/register` with inline handling
- [x] Invalid submission stays on `/register` with inline validation
- [x] Direct visit to `/register/success` without a draft redirects safely
- [x] `npm run lint` passes
- [x] `npm run build` passes

## Notes
This is a transition-step improvement only. It does not imply completed payment or final confirmation, and it preserves the current Stripe stub/check-out scaffold until live payment is enabled.