### PR TITLE
Issue 3-1: Add MVP admin authentication baseline

### DIFF
--- a/app/admin/(protected)/layout.tsx
+++ b/app/admin/(protected)/layout.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation";
+import { isAdminAuthenticated } from "@/lib/admin-auth-server";
+
+export default async function AdminProtectedLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const authenticated = await isAdminAuthenticated();
+
+  if (!authenticated) {
+    redirect("/admin/login");
+  }
+
+  return children;
+}

--- a/app/admin/(protected)/page.tsx
+++ b/app/admin/(protected)/page.tsx
@@ -1,0 +1,29 @@
+export default function AdminPage() {
+  return (
+    <section className="admin-page">
+      <div className="admin-page__intro">
+        <p className="admin-page__eyebrow">Admin</p>
+        <h1 className="admin-page__title">Admin access is active.</h1>
+        <p className="admin-page__lede">
+          This is the protected admin baseline for Settled on the Field. The
+          dashboard work comes next, but access is now limited to the configured
+          admin session.
+        </p>
+      </div>
+
+      <section className="admin-panel">
+        <h2>Current scope</h2>
+        <p>
+          This placeholder confirms the lock on the door is working without
+          expanding into dashboard features ahead of scope.
+        </p>
+
+        <form action="/api/admin/logout" method="post">
+          <button className="admin-button" type="submit">
+            Log Out
+          </button>
+        </form>
+      </section>
+    </section>
+  );
+}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,3 +1,6 @@
+import { redirect } from "next/navigation";
+import { isAdminAuthenticated } from "@/lib/admin-auth-server";
+
 type AdminLoginPageProps = {
   searchParams?: Promise<{
     error?: string;
@@ -7,135 +10,59 @@ type AdminLoginPageProps = {
 export default async function AdminLoginPage({
   searchParams,
 }: AdminLoginPageProps) {
+  const authenticated = await isAdminAuthenticated();
+
+  if (authenticated) {
+    redirect("/admin");
+  }
+
   const resolvedSearchParams = await searchParams;
   const showError = resolvedSearchParams?.error === "invalid";
 
   return (
-    <main
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "2rem",
-        backgroundColor: "#f5f7fa",
-      }}
-    >
-      <div
-        style={{
-          width: "100%",
-          maxWidth: "420px",
-          padding: "2rem",
-          border: "1px solid #d0d7de",
-          borderRadius: "12px",
-          backgroundColor: "#ffffff",
-          boxShadow: "0 8px 24px rgba(15, 23, 42, 0.08)",
-        }}
-      >
-        <h1
-          style={{
-            margin: "0 0 0.5rem",
-            fontSize: "1.75rem",
-            lineHeight: 1.2,
-          }}
-        >
-          Admin Login
-        </h1>
-        <p
-          style={{
-            margin: "0 0 1.5rem",
-            color: "#4b5563",
-            lineHeight: 1.5,
-          }}
-        >
-          Sign in to access the admin area.
+    <section className="admin-login-page">
+      <div className="admin-login-card">
+        <p className="admin-login-card__eyebrow">Admin</p>
+        <h1 className="admin-login-card__title">Sign in to continue.</h1>
+        <p className="admin-login-card__lede">
+          Use the configured admin credentials to access the protected control
+          area.
         </p>
 
         {showError ? (
-          <p
-            style={{
-              margin: "0 0 1rem",
-              color: "#b91c1c",
-              lineHeight: 1.5,
-            }}
-          >
+          <p className="admin-login-card__error">
             Invalid email or password.
           </p>
         ) : null}
 
         <form action="/api/admin/login" method="post">
-          <div style={{ marginBottom: "1rem" }}>
-            <label
-              htmlFor="email"
-              style={{
-                display: "block",
-                marginBottom: "0.5rem",
-                fontWeight: 600,
-              }}
-            >
-              Email
-            </label>
+          <label className="admin-field" htmlFor="email">
+            <span>Email</span>
             <input
               id="email"
               name="email"
               type="email"
               autoComplete="email"
-              style={{
-                width: "100%",
-                padding: "0.75rem",
-                border: "1px solid #cbd5e1",
-                borderRadius: "8px",
-                fontSize: "1rem",
-                boxSizing: "border-box",
-              }}
+              required
             />
-          </div>
+          </label>
 
-          <div style={{ marginBottom: "1.5rem" }}>
-            <label
-              htmlFor="password"
-              style={{
-                display: "block",
-                marginBottom: "0.5rem",
-                fontWeight: 600,
-              }}
-            >
-              Password
-            </label>
+          <label className="admin-field" htmlFor="password">
+            <span>Password</span>
             <input
               id="password"
               name="password"
               type="password"
               autoComplete="current-password"
-              style={{
-                width: "100%",
-                padding: "0.75rem",
-                border: "1px solid #cbd5e1",
-                borderRadius: "8px",
-                fontSize: "1rem",
-                boxSizing: "border-box",
-              }}
+              required
             />
-          </div>
+          </label>
 
-          <button
-            type="submit"
-            style={{
-              width: "100%",
-              padding: "0.875rem",
-              border: "none",
-              borderRadius: "8px",
-              backgroundColor: "#111827",
-              color: "#ffffff",
-              fontSize: "1rem",
-              fontWeight: 600,
-              cursor: "pointer",
-            }}
-          >
+          <button className="admin-button admin-button--full" type="submit">
             Sign In
           </button>
         </form>
       </div>
-    </main>
+    </section>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -575,6 +575,129 @@ a {
   color: var(--color-primary);
 }
 
+.admin-login-page,
+.admin-page {
+  padding-top: var(--space-8);
+  padding-bottom: var(--space-8);
+}
+
+.admin-login-page {
+  display: flex;
+  justify-content: center;
+}
+
+.admin-login-card,
+.admin-panel {
+  width: 100%;
+  max-width: 28rem;
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.admin-login-card__eyebrow,
+.admin-page__eyebrow {
+  margin: 0 0 var(--space-4);
+  color: var(--color-accent);
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.admin-login-card__title,
+.admin-page__title {
+  margin: 0 0 var(--space-4);
+  color: var(--color-primary);
+  font-size: 2.25rem;
+  line-height: 1.1;
+}
+
+.admin-login-card__lede,
+.admin-page__lede,
+.admin-panel p {
+  margin: 0;
+  color: var(--color-accent);
+  line-height: 1.5;
+}
+
+.admin-login-card__error {
+  margin: var(--space-6) 0 0;
+  color: var(--color-primary);
+  line-height: 1.5;
+}
+
+.admin-login-card form {
+  display: grid;
+  gap: var(--space-6);
+  margin-top: var(--space-6);
+}
+
+.admin-field {
+  display: grid;
+  gap: 0.625rem;
+  color: var(--color-primary);
+}
+
+.admin-field span {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.admin-field input {
+  width: 100%;
+  min-height: 3.25rem;
+  border: 1px solid var(--color-border);
+  padding: 0.9375rem 1rem;
+  background: var(--color-background);
+  color: var(--color-text);
+  font: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.admin-field input:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.admin-button {
+  display: inline-block;
+  border: 0;
+  min-height: 3.5rem;
+  padding: var(--space-4) var(--space-6);
+  background: var(--color-primary);
+  color: var(--color-background);
+  font: inherit;
+  font-weight: 600;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.admin-button--full {
+  width: 100%;
+}
+
+.admin-page__intro {
+  max-width: 42rem;
+  margin-bottom: var(--space-8);
+}
+
+.admin-panel {
+  max-width: 40rem;
+}
+
+.admin-panel h2 {
+  margin: 0 0 0.75rem;
+  color: var(--color-primary);
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.admin-panel form {
+  margin-top: var(--space-6);
+}
+
 @media (min-width: 64rem) {
   .register-page__grid {
     grid-template-columns: minmax(0, 1.7fr) minmax(18rem, 1fr);
@@ -608,6 +731,11 @@ a {
 
   .register-success-page__intro {
     margin-bottom: var(--space-6);
+  }
+
+  .admin-login-card__title,
+  .admin-page__title {
+    font-size: 2rem;
   }
 
   .register-page__title {

--- a/lib/admin-auth-server.ts
+++ b/lib/admin-auth-server.ts
@@ -1,0 +1,13 @@
+import { cookies } from "next/headers";
+import {
+  getAdminSessionCookieName,
+  isAdminSessionValueValid,
+} from "@/lib/admin-auth";
+
+export async function isAdminAuthenticated() {
+  const cookieStore = await cookies();
+
+  return isAdminSessionValueValid(
+    cookieStore.get(getAdminSessionCookieName())?.value,
+  );
+}

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -3,15 +3,24 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 const ADMIN_SESSION_COOKIE = "admin_session";
 const ADMIN_SESSION_DURATION_SECONDS = 60 * 60 * 8;
 
-function getSessionSecret() {
-  const adminEmail = process.env.ADMIN_EMAIL;
-  const adminPassword = process.env.ADMIN_PASSWORD;
+function normalizeAdminEmail(value: string) {
+  return value.trim().toLowerCase();
+}
 
-  if (!adminEmail || !adminPassword) {
+function getAdminAuthConfig() {
+  const adminEmail = process.env.ADMIN_EMAIL?.trim();
+  const adminPassword = process.env.ADMIN_PASSWORD;
+  const sessionSecret = process.env.ADMIN_SESSION_SECRET?.trim();
+
+  if (!adminEmail || !adminPassword || !sessionSecret) {
     return null;
   }
 
-  return process.env.ADMIN_SESSION_SECRET ?? `${adminEmail}:${adminPassword}`;
+  return {
+    adminEmail: normalizeAdminEmail(adminEmail),
+    adminPassword,
+    sessionSecret,
+  };
 }
 
 function toBase64Url(value: string) {
@@ -52,25 +61,26 @@ export function getAdminSessionCookieOptions() {
 }
 
 export function areAdminCredentialsValid(email: unknown, password: unknown) {
-  const adminEmail = process.env.ADMIN_EMAIL;
-  const adminPassword = process.env.ADMIN_PASSWORD;
+  const config = getAdminAuthConfig();
 
   if (
     typeof email !== "string" ||
     typeof password !== "string" ||
-    !adminEmail ||
-    !adminPassword
+    !config
   ) {
     return false;
   }
 
-  return safeEqual(email, adminEmail) && safeEqual(password, adminPassword);
+  return (
+    safeEqual(normalizeAdminEmail(email), config.adminEmail) &&
+    safeEqual(password, config.adminPassword)
+  );
 }
 
 export function createAdminSessionValue() {
-  const secret = getSessionSecret();
+  const config = getAdminAuthConfig();
 
-  if (!secret) {
+  if (!config) {
     return null;
   }
 
@@ -79,7 +89,7 @@ export function createAdminSessionValue() {
     sub: "admin",
   });
   const encodedPayload = toBase64Url(payload);
-  const signature = signValue(encodedPayload, secret);
+  const signature = signValue(encodedPayload, config.sessionSecret);
 
   return `${encodedPayload}.${signature}`;
 }
@@ -89,9 +99,9 @@ export function isAdminSessionValueValid(value: string | undefined) {
     return false;
   }
 
-  const secret = getSessionSecret();
+  const config = getAdminAuthConfig();
 
-  if (!secret) {
+  if (!config) {
     return false;
   }
 
@@ -101,7 +111,7 @@ export function isAdminSessionValueValid(value: string | undefined) {
     return false;
   }
 
-  const expectedSignature = signValue(encodedPayload, secret);
+  const expectedSignature = signValue(encodedPayload, config.sessionSecret);
 
   if (!safeEqual(signature, expectedSignature)) {
     return false;

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,4 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import {
   getAdminSessionCookieName,
   isAdminSessionValueValid,
@@ -18,10 +17,9 @@ export function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const loginUrl = new URL("/admin/login", request.url);
-  return NextResponse.redirect(loginUrl);
+  return NextResponse.redirect(new URL("/admin/login", request.url));
 }
 
 export const config = {
-  matcher: ["/admin/:path*"],
+  matcher: ["/admin", "/admin/:path*"],
 };


### PR DESCRIPTION
## Summary
Adds the MVP single-admin authentication baseline for the admin area.

## Related Issue
Closes #41 

## Changes
- added signed HTTP-only admin session handling
- protected `/admin` with redirect behavior for logged-out users
- added public `/admin/login`
- added protected admin placeholder shell
- added logout flow that clears access
- removed the old unprotected admin page

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] logged-out visit to `/admin` redirects to `/admin/login`
- [x] invalid login fails cleanly
- [x] valid login grants access to `/admin`
- [x] logout clears session and blocks `/admin` again

## Notes
Uses `ADMIN_EMAIL`, `ADMIN_PASSWORD`, and `ADMIN_SESSION_SECRET`. Fails closed if env vars are missing.