### PR TITLE
Issue 3-2: Add admin dashboard shell

### DIFF
--- a/app/admin/(protected)/page.tsx
+++ b/app/admin/(protected)/page.tsx
@@ -1,28 +1,88 @@
 export default function AdminPage() {
   return (
     <section className="admin-page">
-      <div className="admin-page__intro">
-        <p className="admin-page__eyebrow">Admin</p>
-        <h1 className="admin-page__title">Admin access is active.</h1>
-        <p className="admin-page__lede">
-          This is the protected admin baseline for Settled on the Field. The
-          dashboard work comes next, but access is now limited to the configured
-          admin session.
-        </p>
-      </div>
-
-      <section className="admin-panel">
-        <h2>Current scope</h2>
-        <p>
-          This placeholder confirms the lock on the door is working without
-          expanding into dashboard features ahead of scope.
-        </p>
+      <section className="admin-hero">
+        <div className="admin-hero__content">
+          <p className="admin-page__eyebrow">Admin</p>
+          <h1 className="admin-page__title">Summit control is ready.</h1>
+          <p className="admin-page__lede">
+            This shell gives Settled on the Field a protected operator space for
+            attendee status, speaker coordination, content links, and settings
+            work that will come online in later issues.
+          </p>
+        </div>
 
         <form action="/api/admin/logout" method="post">
           <button className="admin-button" type="submit">
             Log Out
           </button>
         </form>
+      </section>
+
+      <section className="admin-summary">
+        <div className="admin-summary__item">
+          <p className="admin-summary__label">Access</p>
+          <p className="admin-summary__value">Protected</p>
+        </div>
+        <div className="admin-summary__item">
+          <p className="admin-summary__label">Operator model</p>
+          <p className="admin-summary__value">Single admin</p>
+        </div>
+        <div className="admin-summary__item">
+          <p className="admin-summary__label">Current phase</p>
+          <p className="admin-summary__value">Dashboard shell</p>
+        </div>
+      </section>
+
+      <section className="admin-grid" aria-label="Admin areas">
+        <section className="admin-card">
+          <p className="admin-card__eyebrow">Attendees</p>
+          <h2 className="admin-card__title">Registration oversight</h2>
+          <p className="admin-card__body">
+            This area will hold attendee review and status checks once admin
+            data work is added. No live attendee records are loaded yet.
+          </p>
+          <p className="admin-card__status">Coming online next</p>
+        </section>
+
+        <section className="admin-card">
+          <p className="admin-card__eyebrow">Speakers</p>
+          <h2 className="admin-card__title">Speaker coordination</h2>
+          <p className="admin-card__body">
+            Reserved for speaker details, scheduling notes, and operational
+            visibility. CRUD and persistence are intentionally out of scope here.
+          </p>
+          <p className="admin-card__status">Placeholder only</p>
+        </section>
+
+        <section className="admin-card">
+          <p className="admin-card__eyebrow">Content</p>
+          <h2 className="admin-card__title">Links and publishing surfaces</h2>
+          <p className="admin-card__body">
+            This shell keeps a clear home for content links, summit resources,
+            and future publishing controls without wiring those features yet.
+          </p>
+          <p className="admin-card__status">Ready for future routes</p>
+        </section>
+
+        <section className="admin-card">
+          <p className="admin-card__eyebrow">Settings</p>
+          <h2 className="admin-card__title">Operational configuration</h2>
+          <p className="admin-card__body">
+            Intended for low-frequency admin controls such as environment-backed
+            operational settings. Nothing is editable in this issue.
+          </p>
+          <p className="admin-card__status">Not wired yet</p>
+        </section>
+      </section>
+
+      <section className="admin-panel">
+        <h2>Next actions</h2>
+        <p>
+          The admin foundation is now protected and structured. Future issues
+          can add attendee and status features into these sections without
+          reshaping the shell.
+        </p>
       </section>
     </section>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -683,6 +683,78 @@ a {
   margin-bottom: var(--space-8);
 }
 
+.admin-hero {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--space-6);
+  margin-bottom: var(--space-8);
+}
+
+.admin-hero__content {
+  max-width: 42rem;
+}
+
+.admin-summary {
+  display: grid;
+  gap: var(--space-6);
+  margin-bottom: var(--space-8);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.admin-summary__item {
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+
+.admin-summary__label,
+.admin-card__eyebrow,
+.admin-card__status {
+  margin: 0 0 0.5rem;
+  color: var(--color-accent);
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.admin-summary__value {
+  margin: 0;
+  color: var(--color-primary);
+  font-size: 1.125rem;
+  line-height: 1.3;
+}
+
+.admin-grid {
+  display: grid;
+  gap: var(--space-8);
+  margin-bottom: var(--space-8);
+}
+
+.admin-card {
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.admin-card__title {
+  margin: 0 0 0.75rem;
+  color: var(--color-primary);
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.admin-card__body {
+  margin: 0;
+  color: var(--color-accent);
+  line-height: 1.5;
+}
+
+.admin-card__status {
+  padding-top: var(--space-6);
+}
+
 .admin-panel {
   max-width: 40rem;
 }
@@ -713,6 +785,19 @@ a {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: start;
   }
+
+  .admin-summary {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .admin-summary__item {
+    border-top: 0;
+  }
+
+  .admin-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
 }
 
 @media (max-width: 48rem) {
@@ -731,6 +816,10 @@ a {
 
   .register-success-page__intro {
     margin-bottom: var(--space-6);
+  }
+
+  .admin-hero {
+    align-items: start;
   }
 
   .admin-login-card__title,
@@ -765,6 +854,10 @@ a {
   .confirmation-actions__primary,
   .confirmation-actions__secondary {
     width: 100%;
+  }
+
+  .admin-summary {
+    gap: var(--space-4);
   }
 
   .register-success-actions__links {


### PR DESCRIPTION
## Summary
Adds the protected admin dashboard shell so the admin area feels operational and ready for later admin features.

## Related Issue
Closes #46

## Changes
- replaced the protected `/admin` placeholder with a structured dashboard shell
- added a hero and quick status summary
- added placeholder zones for attendees, speakers, content, and settings
- added a next-actions panel
- kept logout visible in the main control area

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] logged in and confirmed `/admin` renders the new dashboard shell
- [x] confirmed logout still works from `/admin`
- [x] confirmed logged-out access to `/admin` is still blocked

## Notes
This issue keeps the dashboard static and truthful. No live admin data is loaded yet.