### PR TITLE
Issue 3-3: Add registration persistence baseline

### DIFF
--- a/app/register/actions.ts
+++ b/app/register/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { redirect } from "next/navigation";
-import { reserveRegistrationEmail } from "@/lib/registration-email-store";
+import { createRegistration } from "@/lib/registration-store";
 import {
   buildRegistrationDraft,
   isHoneypotSubmission,
@@ -34,7 +34,7 @@ export async function submitRegistration(
   }
 
   try {
-    const duplicateStatus = await reserveRegistrationEmail(values.email);
+    const duplicateStatus = await createRegistration(values);
 
     if (duplicateStatus === "duplicate") {
       return {
@@ -47,7 +47,7 @@ export async function submitRegistration(
       };
     }
   } catch (error) {
-    console.error("Unable to reserve registration email", error);
+    console.error("Unable to persist registration", error);
 
     return {
       formError:

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -6,6 +6,10 @@ export async function register() {
   const { initializeRegistrationEmailStore } = await import(
     "@/lib/registration-email-store"
   );
+  const { initializeRegistrationStore } = await import(
+    "@/lib/registration-store"
+  );
 
   await initializeRegistrationEmailStore();
+  await initializeRegistrationStore();
 }

--- a/lib/registration-store.ts
+++ b/lib/registration-store.ts
@@ -1,0 +1,80 @@
+import { getDb } from "@/lib/db";
+import type {
+  DuplicateRegistrationStatus,
+  RegistrationFormValues,
+} from "@/app/register/types";
+
+const REGISTRATIONS_TABLE = "registrations";
+const REGISTRATION_EMAILS_TABLE = "registration_emails";
+let registrationsTablePromise: Promise<void> | null = null;
+
+function buildFullName(values: RegistrationFormValues) {
+  return `${values.firstName} ${values.lastName}`.trim();
+}
+
+export async function initializeRegistrationStore() {
+  if (!registrationsTablePromise) {
+    registrationsTablePromise = getDb()
+      .query(
+        `CREATE TABLE IF NOT EXISTS ${REGISTRATIONS_TABLE} (
+          normalized_email TEXT PRIMARY KEY,
+          full_name TEXT NOT NULL,
+          email TEXT NOT NULL,
+          organization_or_affiliation TEXT,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )`,
+      )
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        registrationsTablePromise = null;
+        throw error;
+      });
+  }
+
+  await registrationsTablePromise;
+}
+
+export async function createRegistration(
+  values: RegistrationFormValues,
+): Promise<DuplicateRegistrationStatus> {
+  const client = await getDb().connect();
+
+  try {
+    await client.query("BEGIN");
+
+    const duplicateResult = await client.query(
+      `INSERT INTO ${REGISTRATION_EMAILS_TABLE} (normalized_email)
+       VALUES ($1)
+       ON CONFLICT (normalized_email) DO NOTHING`,
+      [values.email],
+    );
+
+    if (duplicateResult.rowCount !== 1) {
+      await client.query("ROLLBACK");
+      return "duplicate";
+    }
+
+    await client.query(
+      `INSERT INTO ${REGISTRATIONS_TABLE} (
+        full_name,
+        email,
+        normalized_email,
+        organization_or_affiliation
+      ) VALUES ($1, $2, $3, $4)`,
+      [
+        buildFullName(values),
+        values.email,
+        values.email,
+        values.organization || null,
+      ],
+    );
+
+    await client.query("COMMIT");
+    return "created";
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}


### PR DESCRIPTION
## Summary
Adds the minimum durable registration persistence needed for admin attendee views and later operational workflows.

## Related Issue
Closes #70 

## Changes
- added a durable registrations table
- initialized registration storage at startup
- wrote successful registration submissions into durable storage
- kept duplicate protection behavior aligned with durable persistence in one transaction
- preserved the existing public registration and success flow

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] submitted a valid registration and confirmed redirect to `/register/success`
- [x] confirmed durable registration row was written with expected fields
- [x] confirmed duplicate submission handling still works cleanly

## Notes
This issue adds storage only. It does not add the admin attendee list UI yet.