### PR TITLE
Issue 3-4: Add attendee list view

### DIFF
--- a/app/admin/(protected)/attendees/page.tsx
+++ b/app/admin/(protected)/attendees/page.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import {
+  listRegistrations,
+  type RegistrationRecord,
+} from "@/lib/registration-store";
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatCreatedAt(value: RegistrationRecord["createdAt"]) {
+  return dateFormatter.format(new Date(value));
+}
+
+export default async function AdminAttendeesPage() {
+  const registrations = await listRegistrations();
+
+  return (
+    <section className="admin-page">
+      <section className="admin-hero">
+        <div className="admin-hero__content">
+          <p className="admin-page__eyebrow">Admin</p>
+          <h1 className="admin-page__title">Attendees</h1>
+          <p className="admin-page__lede">
+            Review who has registered so far and keep the summit operator view
+            grounded in the current registration record.
+          </p>
+        </div>
+
+        <Link className="admin-link-button" href="/admin">
+          Back to Dashboard
+        </Link>
+      </section>
+
+      <section className="admin-summary">
+        <div className="admin-summary__item">
+          <p className="admin-summary__label">Registered attendees</p>
+          <p className="admin-summary__value">{registrations.length}</p>
+        </div>
+      </section>
+
+      {registrations.length === 0 ? (
+        <section className="admin-panel">
+          <h2>No attendees yet</h2>
+          <p>
+            Registrations will appear here once people complete the current
+            summit registration flow.
+          </p>
+        </section>
+      ) : (
+        <section className="admin-attendees">
+          <div className="admin-attendees__table-wrap">
+            <table className="admin-attendees__table">
+              <thead>
+                <tr>
+                  <th scope="col">Name</th>
+                  <th scope="col">Email</th>
+                  <th scope="col">Organization</th>
+                  <th scope="col">Registered</th>
+                </tr>
+              </thead>
+              <tbody>
+                {registrations.map((registration) => (
+                  <tr key={registration.normalizedEmail}>
+                    <td>{registration.fullName}</td>
+                    <td>{registration.email}</td>
+                    <td>
+                      {registration.organizationOrAffiliation || "Not provided"}
+                    </td>
+                    <td>{formatCreatedAt(registration.createdAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </section>
+  );
+}

--- a/app/admin/(protected)/page.tsx
+++ b/app/admin/(protected)/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export default function AdminPage() {
   return (
     <section className="admin-page">
@@ -39,10 +41,12 @@ export default function AdminPage() {
           <p className="admin-card__eyebrow">Attendees</p>
           <h2 className="admin-card__title">Registration oversight</h2>
           <p className="admin-card__body">
-            This area will hold attendee review and status checks once admin
-            data work is added. No live attendee records are loaded yet.
+            View the current registration record and see who has already entered
+            the summit pipeline.
           </p>
-          <p className="admin-card__status">Coming online next</p>
+          <Link className="admin-card__link" href="/admin/attendees">
+            View Attendees
+          </Link>
         </section>
 
         <section className="admin-card">

--- a/app/globals.css
+++ b/app/globals.css
@@ -674,6 +674,14 @@ a {
   cursor: pointer;
 }
 
+.admin-link-button,
+.admin-card__link {
+  display: inline-block;
+  color: var(--color-primary);
+  font-weight: 600;
+  line-height: 1.3;
+}
+
 .admin-button--full {
   width: 100%;
 }
@@ -755,6 +763,10 @@ a {
   padding-top: var(--space-6);
 }
 
+.admin-card__link {
+  padding-top: var(--space-6);
+}
+
 .admin-panel {
   max-width: 40rem;
 }
@@ -768,6 +780,40 @@ a {
 
 .admin-panel form {
   margin-top: var(--space-6);
+}
+
+.admin-attendees {
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.admin-attendees__table-wrap {
+  overflow-x: auto;
+}
+
+.admin-attendees__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-attendees__table th,
+.admin-attendees__table td {
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.admin-attendees__table th {
+  color: var(--color-primary);
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.admin-attendees__table td {
+  color: var(--color-accent);
+  line-height: 1.5;
 }
 
 @media (min-width: 64rem) {

--- a/lib/registration-store.ts
+++ b/lib/registration-store.ts
@@ -8,6 +8,14 @@ const REGISTRATIONS_TABLE = "registrations";
 const REGISTRATION_EMAILS_TABLE = "registration_emails";
 let registrationsTablePromise: Promise<void> | null = null;
 
+export type RegistrationRecord = {
+  createdAt: string;
+  email: string;
+  fullName: string;
+  normalizedEmail: string;
+  organizationOrAffiliation: string | null;
+};
+
 function buildFullName(values: RegistrationFormValues) {
   return `${values.firstName} ${values.lastName}`.trim();
 }
@@ -77,4 +85,31 @@ export async function createRegistration(
   } finally {
     client.release();
   }
+}
+
+export async function listRegistrations(): Promise<RegistrationRecord[]> {
+  const result = await getDb().query<{
+    created_at: string;
+    email: string;
+    full_name: string;
+    normalized_email: string;
+    organization_or_affiliation: string | null;
+  }>(
+    `SELECT
+      full_name,
+      email,
+      normalized_email,
+      organization_or_affiliation,
+      created_at
+     FROM ${REGISTRATIONS_TABLE}
+     ORDER BY created_at DESC`,
+  );
+
+  return result.rows.map((row) => ({
+    createdAt: row.created_at,
+    email: row.email,
+    fullName: row.full_name,
+    normalizedEmail: row.normalized_email,
+    organizationOrAffiliation: row.organization_or_affiliation,
+  }));
 }


### PR DESCRIPTION
## Summary
Adds the first real admin data view by introducing a protected attendee list page backed by durable registration data.

## Related Issue
Closes #42 

## Changes
- added protected attendee list page at `/admin/attendees`
- wired dashboard Attendees card to the new page
- added server-side registration read from durable storage
- displayed full_name, email, organization_or_affiliation, and created_at
- added count summary and clean empty state

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] confirmed empty state renders with no registrations
- [x] submitted a real registration and confirmed it appears in the list
- [x] confirmed dashboard navigation to attendee list works
- [x] confirmed logged-out access is blocked

## Notes
Uses only durable registration data. No inferred status or payment logic is introduced.