### PR TITLE
Issue 3-5: Add small-team multi-user admin auth baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,5 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
-# Admin (single-user MVP)
-ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=change_me
-
 # Admin session
 ADMIN_SESSION_SECRET=replace_with_a_long_random_secret

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Admin Bootstrap
+
+Set `DATABASE_URL` and `ADMIN_SESSION_SECRET`, then create admin users with:
+
+```bash
+npm run admin:create-user -- --email admin@example.com --password 'change-me'
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/admin/(protected)/page.tsx
+++ b/app/admin/(protected)/page.tsx
@@ -28,7 +28,7 @@ export default function AdminPage() {
         </div>
         <div className="admin-summary__item">
           <p className="admin-summary__label">Operator model</p>
-          <p className="admin-summary__value">Single admin</p>
+          <p className="admin-summary__value">Small team</p>
         </div>
         <div className="admin-summary__item">
           <p className="admin-summary__label">Current phase</p>

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -25,7 +25,7 @@ export default async function AdminLoginPage({
         <p className="admin-login-card__eyebrow">Admin</p>
         <h1 className="admin-login-card__title">Sign in to continue.</h1>
         <p className="admin-login-card__lede">
-          Use the configured admin credentials to access the protected control
+          Use your admin account credentials to access the protected control
           area.
         </p>
 

--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -1,18 +1,19 @@
 import { NextResponse } from "next/server";
 import {
-  areAdminCredentialsValid,
   createAdminSessionValue,
   getAdminSessionCookieName,
   getAdminSessionCookieOptions,
 } from "@/lib/admin-auth";
+import { authenticateAdminUser } from "@/lib/admin-user-store";
 
 export async function POST(request: Request) {
   const formData = await request.formData();
   const email = formData.get("email");
   const password = formData.get("password");
+  const adminUser = await authenticateAdminUser(email, password);
 
-  if (areAdminCredentialsValid(email, password)) {
-    const sessionValue = createAdminSessionValue();
+  if (adminUser) {
+    const sessionValue = createAdminSessionValue(adminUser.normalizedEmail);
 
     if (!sessionValue) {
       return new Response("Unauthorized", { status: 401 });

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,6 +3,7 @@ export async function register() {
     return;
   }
 
+  const { initializeAdminUserStore } = await import("@/lib/admin-user-store");
   const { initializeRegistrationEmailStore } = await import(
     "@/lib/registration-email-store"
   );
@@ -10,6 +11,7 @@ export async function register() {
     "@/lib/registration-store"
   );
 
+  await initializeAdminUserStore();
   await initializeRegistrationEmailStore();
   await initializeRegistrationStore();
 }

--- a/lib/admin-auth-server.ts
+++ b/lib/admin-auth-server.ts
@@ -1,13 +1,19 @@
 import { cookies } from "next/headers";
 import {
+  getAdminSessionSubject,
   getAdminSessionCookieName,
-  isAdminSessionValueValid,
 } from "@/lib/admin-auth";
+import { findAdminUserByNormalizedEmail } from "@/lib/admin-user-store";
 
 export async function isAdminAuthenticated() {
   const cookieStore = await cookies();
-
-  return isAdminSessionValueValid(
+  const subject = getAdminSessionSubject(
     cookieStore.get(getAdminSessionCookieName())?.value,
   );
+
+  if (!subject) {
+    return false;
+  }
+
+  return (await findAdminUserByNormalizedEmail(subject)) !== null;
 }

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -3,24 +3,14 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 const ADMIN_SESSION_COOKIE = "admin_session";
 const ADMIN_SESSION_DURATION_SECONDS = 60 * 60 * 8;
 
-function normalizeAdminEmail(value: string) {
-  return value.trim().toLowerCase();
-}
-
-function getAdminAuthConfig() {
-  const adminEmail = process.env.ADMIN_EMAIL?.trim();
-  const adminPassword = process.env.ADMIN_PASSWORD;
+function getAdminSessionSecret() {
   const sessionSecret = process.env.ADMIN_SESSION_SECRET?.trim();
 
-  if (!adminEmail || !adminPassword || !sessionSecret) {
+  if (!sessionSecret) {
     return null;
   }
 
-  return {
-    adminEmail: normalizeAdminEmail(adminEmail),
-    adminPassword,
-    sessionSecret,
-  };
+  return sessionSecret;
 }
 
 function toBase64Url(value: string) {
@@ -60,61 +50,44 @@ export function getAdminSessionCookieOptions() {
   };
 }
 
-export function areAdminCredentialsValid(email: unknown, password: unknown) {
-  const config = getAdminAuthConfig();
+export function createAdminSessionValue(subject: string) {
+  const sessionSecret = getAdminSessionSecret();
 
-  if (
-    typeof email !== "string" ||
-    typeof password !== "string" ||
-    !config
-  ) {
-    return false;
-  }
-
-  return (
-    safeEqual(normalizeAdminEmail(email), config.adminEmail) &&
-    safeEqual(password, config.adminPassword)
-  );
-}
-
-export function createAdminSessionValue() {
-  const config = getAdminAuthConfig();
-
-  if (!config) {
+  if (!sessionSecret || !subject) {
     return null;
   }
 
   const payload = JSON.stringify({
     exp: Date.now() + ADMIN_SESSION_DURATION_SECONDS * 1000,
-    sub: "admin",
+    sub: subject,
   });
   const encodedPayload = toBase64Url(payload);
-  const signature = signValue(encodedPayload, config.sessionSecret);
+  const signature = signValue(encodedPayload, sessionSecret);
 
   return `${encodedPayload}.${signature}`;
 }
 
-export function isAdminSessionValueValid(value: string | undefined) {
+export function getAdminSessionSubject(value: string | undefined) {
   if (!value) {
-    return false;
+    return null;
   }
 
-  const config = getAdminAuthConfig();
+  const sessionSecret = getAdminSessionSecret();
 
-  if (!config) {
-    return false;
+  if (!sessionSecret) {
+    return null;
   }
 
   const [encodedPayload, signature] = value.split(".");
 
   if (!encodedPayload || !signature) {
-    return false;
+    return null;
   }
 
-  const expectedSignature = signValue(encodedPayload, config.sessionSecret);
+  const expectedSignature = signValue(encodedPayload, sessionSecret);
 
   if (!safeEqual(signature, expectedSignature)) {
-    return false;
+    return null;
   }
 
   try {
@@ -123,8 +96,16 @@ export function isAdminSessionValueValid(value: string | undefined) {
       sub?: string;
     };
 
-    return payload.sub === "admin" && typeof payload.exp === "number" && payload.exp > Date.now();
+    if (typeof payload.exp !== "number" || payload.exp <= Date.now()) {
+      return null;
+    }
+
+    return typeof payload.sub === "string" && payload.sub ? payload.sub : null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+export function isAdminSessionValueValid(value: string | undefined) {
+  return getAdminSessionSubject(value) !== null;
 }

--- a/lib/admin-user-store.ts
+++ b/lib/admin-user-store.ts
@@ -1,0 +1,186 @@
+import { randomBytes, scrypt as nodeScrypt, timingSafeEqual } from "node:crypto";
+import { promisify } from "node:util";
+import { getDb } from "@/lib/db";
+
+const ADMIN_USERS_TABLE = "admin_users";
+const SCRYPT_KEY_LENGTH = 64;
+const scrypt = promisify(nodeScrypt);
+
+let adminUsersTablePromise: Promise<void> | null = null;
+
+type AdminUserRow = {
+  created_at: string;
+  email: string;
+  normalized_email: string;
+  password_hash: string;
+};
+
+export type AdminUserRecord = {
+  createdAt: string;
+  email: string;
+  normalizedEmail: string;
+  passwordHash: string;
+};
+
+export function normalizeAdminEmail(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function mapAdminUserRow(row: AdminUserRow): AdminUserRecord {
+  return {
+    createdAt: row.created_at,
+    email: row.email,
+    normalizedEmail: row.normalized_email,
+    passwordHash: row.password_hash,
+  };
+}
+
+function getStoredHashParts(passwordHash: string) {
+  const [salt, expectedHash] = passwordHash.split(":");
+
+  if (!salt || !expectedHash) {
+    return null;
+  }
+
+  return {
+    expectedHash,
+    salt,
+  };
+}
+
+async function hashPassword(password: string) {
+  const salt = randomBytes(16).toString("hex");
+  const derivedKey = (await scrypt(
+    password,
+    salt,
+    SCRYPT_KEY_LENGTH,
+  )) as Buffer;
+
+  return `${salt}:${derivedKey.toString("hex")}`;
+}
+
+async function verifyPassword(password: string, passwordHash: string) {
+  const parts = getStoredHashParts(passwordHash);
+
+  if (!parts) {
+    return false;
+  }
+
+  const actualHash = (await scrypt(
+    password,
+    parts.salt,
+    SCRYPT_KEY_LENGTH,
+  )) as Buffer;
+  const expectedHash = Buffer.from(parts.expectedHash, "hex");
+
+  if (actualHash.length !== expectedHash.length) {
+    return false;
+  }
+
+  return timingSafeEqual(actualHash, expectedHash);
+}
+
+export async function initializeAdminUserStore() {
+  if (!adminUsersTablePromise) {
+    adminUsersTablePromise = getDb()
+      .query(
+        `CREATE TABLE IF NOT EXISTS ${ADMIN_USERS_TABLE} (
+          normalized_email TEXT PRIMARY KEY,
+          email TEXT NOT NULL,
+          password_hash TEXT NOT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )`,
+      )
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        adminUsersTablePromise = null;
+        throw error;
+      });
+  }
+
+  await adminUsersTablePromise;
+}
+
+export async function findAdminUserByNormalizedEmail(
+  normalizedEmail: string,
+): Promise<AdminUserRecord | null> {
+  const result = await getDb().query<AdminUserRow>(
+    `SELECT
+      normalized_email,
+      email,
+      password_hash,
+      created_at
+     FROM ${ADMIN_USERS_TABLE}
+     WHERE normalized_email = $1`,
+    [normalizedEmail],
+  );
+
+  if (result.rowCount !== 1) {
+    return null;
+  }
+
+  return mapAdminUserRow(result.rows[0]);
+}
+
+export async function authenticateAdminUser(
+  email: unknown,
+  password: unknown,
+): Promise<AdminUserRecord | null> {
+  if (typeof email !== "string" || typeof password !== "string") {
+    return null;
+  }
+
+  const normalizedEmail = normalizeAdminEmail(email);
+
+  if (!normalizedEmail || !password) {
+    return null;
+  }
+
+  const adminUser = await findAdminUserByNormalizedEmail(normalizedEmail);
+
+  if (!adminUser) {
+    return null;
+  }
+
+  const passwordMatches = await verifyPassword(password, adminUser.passwordHash);
+
+  return passwordMatches ? adminUser : null;
+}
+
+export async function upsertAdminUser({
+  email,
+  password,
+}: {
+  email: string;
+  password: string;
+}) {
+  const normalizedEmail = normalizeAdminEmail(email);
+
+  if (!normalizedEmail) {
+    throw new Error("Admin email is required");
+  }
+
+  if (!password) {
+    throw new Error("Admin password is required");
+  }
+
+  const passwordHash = await hashPassword(password);
+  const result = await getDb().query<AdminUserRow>(
+    `INSERT INTO ${ADMIN_USERS_TABLE} (
+      normalized_email,
+      email,
+      password_hash
+    ) VALUES ($1, $2, $3)
+    ON CONFLICT (normalized_email) DO UPDATE
+      SET email = EXCLUDED.email,
+          password_hash = EXCLUDED.password_hash
+    RETURNING
+      normalized_email,
+      email,
+      password_hash,
+      created_at`,
+    [normalizedEmail, email.trim(), passwordHash],
+  );
+
+  return mapAdminUserRow(result.rows[0]);
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "admin:create-user": "node scripts/create-admin-user.mjs",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/scripts/create-admin-user.mjs
+++ b/scripts/create-admin-user.mjs
@@ -1,0 +1,85 @@
+import { randomBytes, scryptSync } from "node:crypto";
+import process from "node:process";
+import pg from "pg";
+
+const { Client } = pg;
+const ADMIN_USERS_TABLE = "admin_users";
+const SCRYPT_KEY_LENGTH = 64;
+
+function getArgValue(flag) {
+  const flagIndex = process.argv.indexOf(flag);
+
+  if (flagIndex === -1) {
+    return null;
+  }
+
+  return process.argv[flagIndex + 1] ?? null;
+}
+
+function normalizeEmail(value) {
+  return value.trim().toLowerCase();
+}
+
+function hashPassword(password) {
+  const salt = randomBytes(16).toString("hex");
+  const derivedKey = scryptSync(password, salt, SCRYPT_KEY_LENGTH);
+
+  return `${salt}:${derivedKey.toString("hex")}`;
+}
+
+async function main() {
+  const email = getArgValue("--email");
+  const password = getArgValue("--password");
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not set");
+  }
+
+  if (!email || !normalizeEmail(email)) {
+    throw new Error("Pass --email with a valid admin email");
+  }
+
+  if (!password) {
+    throw new Error("Pass --password with a non-empty admin password");
+  }
+
+  const client = new Client({ connectionString: databaseUrl });
+
+  await client.connect();
+
+  try {
+    await client.query(
+      `CREATE TABLE IF NOT EXISTS ${ADMIN_USERS_TABLE} (
+        normalized_email TEXT PRIMARY KEY,
+        email TEXT NOT NULL,
+        password_hash TEXT NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )`,
+    );
+
+    const normalizedEmail = normalizeEmail(email);
+    const passwordHash = hashPassword(password);
+
+    await client.query(
+      `INSERT INTO ${ADMIN_USERS_TABLE} (
+        normalized_email,
+        email,
+        password_hash
+      ) VALUES ($1, $2, $3)
+      ON CONFLICT (normalized_email) DO UPDATE
+        SET email = EXCLUDED.email,
+            password_hash = EXCLUDED.password_hash`,
+      [normalizedEmail, email.trim(), passwordHash],
+    );
+
+    console.log(`Admin user ready: ${normalizedEmail}`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Replaces the single shared admin credential model with a small-team multi-user admin auth baseline.

## Related Issue
Closes #67 

## Changes
- added durable `admin_users` storage
- added hashed password verification for admin login
- updated login to validate against DB-backed admin users
- kept the existing signed HTTP-only session model
- revalidated protected admin access against current user records
- added CLI bootstrap path for creating initial admin users
- updated admin shell copy from single-admin to small-team language

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] created two admin users with the bootstrap path
- [x] confirmed invalid login fails cleanly
- [x] confirmed both admin users can log in separately
- [x] confirmed logout still works
- [x] confirmed logged-out access to protected admin routes is blocked

## Notes
This issue adds DB-backed small-team admin access only. It does not add password reset, invite flow, roles, or admin user management UI.