### PR TITLE
Issue 3-6: Add owner/admin role baseline for admin users

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Set `DATABASE_URL` and `ADMIN_SESSION_SECRET`, then create admin users with:
 npm run admin:create-user -- --email admin@example.com --password 'change-me'
 ```
 
+To establish the initial owner deliberately, pass `--role owner`. Omit `--role`
+or pass `--role admin` for helper admins.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/lib/admin-auth-server.ts
+++ b/lib/admin-auth-server.ts
@@ -3,17 +3,32 @@ import {
   getAdminSessionSubject,
   getAdminSessionCookieName,
 } from "@/lib/admin-auth";
-import { findAdminUserByNormalizedEmail } from "@/lib/admin-user-store";
+import {
+  type AdminUserRecord,
+  findAdminUserByNormalizedEmail,
+} from "@/lib/admin-user-store";
 
-export async function isAdminAuthenticated() {
+async function getCurrentAdminUser(): Promise<AdminUserRecord | null> {
   const cookieStore = await cookies();
   const subject = getAdminSessionSubject(
     cookieStore.get(getAdminSessionCookieName())?.value,
   );
 
   if (!subject) {
-    return false;
+    return null;
   }
 
-  return (await findAdminUserByNormalizedEmail(subject)) !== null;
+  return await findAdminUserByNormalizedEmail(subject);
+}
+
+export async function isAdminAuthenticated() {
+  return (await getCurrentAdminUser()) !== null;
+}
+
+export async function getCurrentAdminRole() {
+  return (await getCurrentAdminUser())?.role ?? null;
+}
+
+export async function isCurrentAdminOwner() {
+  return (await getCurrentAdminRole()) === "owner";
 }

--- a/lib/admin-user-store.ts
+++ b/lib/admin-user-store.ts
@@ -13,13 +13,19 @@ type AdminUserRow = {
   email: string;
   normalized_email: string;
   password_hash: string;
+  role: string;
 };
+
+export const ADMIN_USER_ROLES = ["owner", "admin"] as const;
+
+export type AdminUserRole = (typeof ADMIN_USER_ROLES)[number];
 
 export type AdminUserRecord = {
   createdAt: string;
   email: string;
   normalizedEmail: string;
   passwordHash: string;
+  role: AdminUserRole;
 };
 
 export function normalizeAdminEmail(value: string) {
@@ -27,12 +33,27 @@ export function normalizeAdminEmail(value: string) {
 }
 
 function mapAdminUserRow(row: AdminUserRow): AdminUserRecord {
+  const role = parseAdminUserRole(row.role);
+
+  if (!role) {
+    throw new Error(`Invalid admin user role for ${row.normalized_email}`);
+  }
+
   return {
     createdAt: row.created_at,
     email: row.email,
     normalizedEmail: row.normalized_email,
     passwordHash: row.password_hash,
+    role,
   };
+}
+
+export function parseAdminUserRole(value: unknown): AdminUserRole | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  return ADMIN_USER_ROLES.find((role) => role === value) ?? null;
 }
 
 function getStoredHashParts(passwordHash: string) {
@@ -83,13 +104,41 @@ async function verifyPassword(password: string, passwordHash: string) {
 export async function initializeAdminUserStore() {
   if (!adminUsersTablePromise) {
     adminUsersTablePromise = getDb()
-      .query(
-        `CREATE TABLE IF NOT EXISTS ${ADMIN_USERS_TABLE} (
-          normalized_email TEXT PRIMARY KEY,
-          email TEXT NOT NULL,
-          password_hash TEXT NOT NULL,
-          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-        )`,
+      .query(`CREATE TABLE IF NOT EXISTS ${ADMIN_USERS_TABLE} (
+        normalized_email TEXT PRIMARY KEY,
+        email TEXT NOT NULL,
+        password_hash TEXT NOT NULL,
+        role TEXT NOT NULL DEFAULT 'admin',
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )`)
+      .then(() =>
+        getDb().query(
+          `ALTER TABLE ${ADMIN_USERS_TABLE}
+           ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'admin'`,
+        ),
+      )
+      .then(() =>
+        getDb().query(
+          `UPDATE ${ADMIN_USERS_TABLE}
+           SET role = 'admin'
+           WHERE role IS NULL`,
+        ),
+      )
+      .then(() =>
+        getDb().query(
+          `DO $$
+          BEGIN
+            IF NOT EXISTS (
+              SELECT 1
+              FROM pg_constraint
+              WHERE conname = '${ADMIN_USERS_TABLE}_role_check'
+            ) THEN
+              ALTER TABLE ${ADMIN_USERS_TABLE}
+              ADD CONSTRAINT ${ADMIN_USERS_TABLE}_role_check
+              CHECK (role IN ('owner', 'admin'));
+            END IF;
+          END $$;`,
+        ),
       )
       .then(() => undefined)
       .catch((error: unknown) => {
@@ -109,6 +158,7 @@ export async function findAdminUserByNormalizedEmail(
       normalized_email,
       email,
       password_hash,
+      role,
       created_at
      FROM ${ADMIN_USERS_TABLE}
      WHERE normalized_email = $1`,
@@ -150,9 +200,11 @@ export async function authenticateAdminUser(
 export async function upsertAdminUser({
   email,
   password,
+  role,
 }: {
   email: string;
   password: string;
+  role: AdminUserRole;
 }) {
   const normalizedEmail = normalizeAdminEmail(email);
 
@@ -164,23 +216,51 @@ export async function upsertAdminUser({
     throw new Error("Admin password is required");
   }
 
+  if (!parseAdminUserRole(role)) {
+    throw new Error("Admin role must be owner or admin");
+  }
+
   const passwordHash = await hashPassword(password);
   const result = await getDb().query<AdminUserRow>(
     `INSERT INTO ${ADMIN_USERS_TABLE} (
       normalized_email,
       email,
-      password_hash
-    ) VALUES ($1, $2, $3)
+      password_hash,
+      role
+    ) VALUES ($1, $2, $3, $4)
     ON CONFLICT (normalized_email) DO UPDATE
       SET email = EXCLUDED.email,
-          password_hash = EXCLUDED.password_hash
+          password_hash = EXCLUDED.password_hash,
+          role = EXCLUDED.role
     RETURNING
       normalized_email,
       email,
       password_hash,
+      role,
       created_at`,
-    [normalizedEmail, email.trim(), passwordHash],
+    [normalizedEmail, email.trim(), passwordHash, role],
   );
+
+  return mapAdminUserRow(result.rows[0]);
+}
+
+export async function getOwnerAdminUser(): Promise<AdminUserRecord | null> {
+  const result = await getDb().query<AdminUserRow>(
+    `SELECT
+      normalized_email,
+      email,
+      password_hash,
+      role,
+      created_at
+     FROM ${ADMIN_USERS_TABLE}
+     WHERE role = 'owner'
+     ORDER BY created_at ASC
+     LIMIT 1`,
+  );
+
+  if (result.rowCount !== 1) {
+    return null;
+  }
 
   return mapAdminUserRow(result.rows[0]);
 }

--- a/scripts/create-admin-user.mjs
+++ b/scripts/create-admin-user.mjs
@@ -5,6 +5,7 @@ import pg from "pg";
 const { Client } = pg;
 const ADMIN_USERS_TABLE = "admin_users";
 const SCRYPT_KEY_LENGTH = 64;
+const ADMIN_USER_ROLES = new Set(["owner", "admin"]);
 
 function getArgValue(flag) {
   const flagIndex = process.argv.indexOf(flag);
@@ -27,9 +28,20 @@ function hashPassword(password) {
   return `${salt}:${derivedKey.toString("hex")}`;
 }
 
+function parseRole(value) {
+  if (typeof value !== "string") {
+    return "admin";
+  }
+
+  const normalizedValue = value.trim().toLowerCase();
+
+  return ADMIN_USER_ROLES.has(normalizedValue) ? normalizedValue : null;
+}
+
 async function main() {
   const email = getArgValue("--email");
   const password = getArgValue("--password");
+  const role = parseRole(getArgValue("--role"));
   const databaseUrl = process.env.DATABASE_URL;
 
   if (!databaseUrl) {
@@ -44,6 +56,10 @@ async function main() {
     throw new Error("Pass --password with a non-empty admin password");
   }
 
+  if (!role) {
+    throw new Error("Pass --role with owner or admin");
+  }
+
   const client = new Client({ connectionString: databaseUrl });
 
   await client.connect();
@@ -54,26 +70,84 @@ async function main() {
         normalized_email TEXT PRIMARY KEY,
         email TEXT NOT NULL,
         password_hash TEXT NOT NULL,
+        role TEXT NOT NULL DEFAULT 'admin',
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
       )`,
     );
 
+    await client.query(
+      `ALTER TABLE ${ADMIN_USERS_TABLE}
+       ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'admin'`,
+    );
+
+    await client.query(
+      `UPDATE ${ADMIN_USERS_TABLE}
+       SET role = 'admin'
+       WHERE role IS NULL`,
+    );
+
+    await client.query(
+      `DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_constraint
+          WHERE conname = '${ADMIN_USERS_TABLE}_role_check'
+        ) THEN
+          ALTER TABLE ${ADMIN_USERS_TABLE}
+          ADD CONSTRAINT ${ADMIN_USERS_TABLE}_role_check
+          CHECK (role IN ('owner', 'admin'));
+        END IF;
+      END $$;`,
+    );
+
     const normalizedEmail = normalizeEmail(email);
     const passwordHash = hashPassword(password);
+    const existingOwner = await client.query(
+      `SELECT normalized_email
+       FROM ${ADMIN_USERS_TABLE}
+       WHERE role = 'owner'
+       LIMIT 1`,
+    );
+
+    if (
+      role === "owner" &&
+      existingOwner.rowCount === 1 &&
+      existingOwner.rows[0].normalized_email !== normalizedEmail
+    ) {
+      throw new Error("An owner already exists; refusing to create a second owner");
+    }
+
+    const existingUser = await client.query(
+      `SELECT role
+       FROM ${ADMIN_USERS_TABLE}
+       WHERE normalized_email = $1`,
+      [normalizedEmail],
+    );
+
+    if (
+      role === "admin" &&
+      existingUser.rowCount === 1 &&
+      existingUser.rows[0].role === "owner"
+    ) {
+      throw new Error("Refusing to demote the existing owner through this command");
+    }
 
     await client.query(
       `INSERT INTO ${ADMIN_USERS_TABLE} (
         normalized_email,
         email,
-        password_hash
-      ) VALUES ($1, $2, $3)
+        password_hash,
+        role
+      ) VALUES ($1, $2, $3, $4)
       ON CONFLICT (normalized_email) DO UPDATE
         SET email = EXCLUDED.email,
-            password_hash = EXCLUDED.password_hash`,
-      [normalizedEmail, email.trim(), passwordHash],
+            password_hash = EXCLUDED.password_hash,
+            role = EXCLUDED.role`,
+      [normalizedEmail, email.trim(), passwordHash, role],
     );
 
-    console.log(`Admin user ready: ${normalizedEmail}`);
+    console.log(`Admin user ready: ${normalizedEmail} (${role})`);
   } finally {
     await client.end();
   }


### PR DESCRIPTION
## Summary
Adds the durable owner/admin role baseline for admin users so the system can distinguish the owner from normal helper admins.

## Related Issue
Closes #74 

## Changes
- added durable `role` support to admin users
- restricted valid roles to `owner` and `admin`
- backfilled existing admin users to `admin`
- added DB and app-layer validation for role values
- added server-side role helpers for future owner-only checks
- updated the admin bootstrap CLI to support deliberate owner creation

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] created one owner and one admin user
- [x] confirmed both roles persist correctly
- [x] confirmed both roles can still log into `/admin`
- [x] confirmed protected admin routes still work

## Notes
This issue establishes the role seam only. It does not add admin-user management UI yet.