### PR TITLE
Issue 3-9: add safe admin user removal

### DIFF
--- a/app/admin/(protected)/users/page.tsx
+++ b/app/admin/(protected)/users/page.tsx
@@ -13,6 +13,7 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
 
 type AdminUsersPageProps = {
   searchParams?: Promise<{
+    confirmRemove?: string;
     error?: string;
     status?: string;
   }>;
@@ -55,7 +56,19 @@ function getFeedbackCopy(status?: string, error?: string) {
     };
   }
 
-  if (error === "invalid" || error === "disable-invalid") {
+  if (status === "user-removed") {
+    return {
+      tone: "status",
+      title: "User removed",
+      body: "That account has been removed permanently.",
+    };
+  }
+
+  if (
+    error === "invalid" ||
+    error === "disable-invalid" ||
+    error === "remove-invalid"
+  ) {
     return {
       tone: "error",
       title: "That action could not be completed",
@@ -86,6 +99,14 @@ export default async function AdminUsersPage({
     resolvedSearchParams?.status,
     resolvedSearchParams?.error,
   );
+  const pendingRemoveEmail = resolvedSearchParams?.confirmRemove ?? null;
+  const pendingRemoveUser = pendingRemoveEmail
+    ? adminUsers.find((user) => user.normalizedEmail === pendingRemoveEmail) ?? null
+    : null;
+  const pendingRemoveIsLastActiveOwner =
+    pendingRemoveUser?.role === "owner" &&
+    pendingRemoveUser.isActive &&
+    activeOwners.length === 1;
 
   return (
     <section className="admin-page">
@@ -123,6 +144,41 @@ export default async function AdminUsersPage({
         <section className={`admin-panel admin-panel--${feedback.tone}`}>
           <h2>{feedback.title}</h2>
           <p>{feedback.body}</p>
+        </section>
+      ) : null}
+
+      {pendingRemoveUser ? (
+        <section className="admin-panel admin-panel--warning">
+          <h2>Remove user</h2>
+          <p>
+            Remove access permanently for <strong>{pendingRemoveUser.email}</strong>.
+            This cannot be undone from the app.
+          </p>
+          {pendingRemoveIsLastActiveOwner ? (
+            <p>Keep one owner active before removing this account.</p>
+          ) : (
+            <form action="/api/admin/users/remove" method="post">
+              <input
+                type="hidden"
+                name="normalizedEmail"
+                value={pendingRemoveUser.normalizedEmail}
+              />
+              <input type="hidden" name="confirmation" value="remove" />
+              <div className="admin-users__confirmation-actions">
+                <button className="admin-button admin-button--danger" type="submit">
+                  Remove access permanently
+                </button>
+                <Link className="admin-link-button" href="/admin/users">
+                  Cancel
+                </Link>
+              </div>
+            </form>
+          )}
+        </section>
+      ) : pendingRemoveEmail ? (
+        <section className="admin-panel admin-panel--error">
+          <h2>That action could not be completed</h2>
+          <p>The selected user could not be found.</p>
         </section>
       ) : null}
 
@@ -191,6 +247,9 @@ export default async function AdminUsersPage({
                   adminUser.role === "owner" &&
                   adminUser.isActive &&
                   activeOwners.length === 1;
+                const removeHref = `/admin/users?confirmRemove=${encodeURIComponent(
+                  adminUser.normalizedEmail,
+                )}`;
 
                 return (
                   <tr key={adminUser.normalizedEmail}>
@@ -209,12 +268,8 @@ export default async function AdminUsersPage({
                     </td>
                     <td>{formatCreatedAt(adminUser.createdAt)}</td>
                     <td>
-                      {adminUser.isActive ? (
-                        isLastActiveOwner ? (
-                          <span className="admin-users__action-note">
-                            Keep active
-                          </span>
-                        ) : (
+                      <div className="admin-users__actions">
+                        {adminUser.isActive ? (
                           <form
                             action="/api/admin/users/disable"
                             method="post"
@@ -228,18 +283,33 @@ export default async function AdminUsersPage({
                             <button
                               className="admin-link-button admin-users__disable-button"
                               type="submit"
-                              disabled={
-                                currentAdminUser?.normalizedEmail ===
-                                  adminUser.normalizedEmail && isLastActiveOwner
-                              }
                             >
                               Disable
                             </button>
                           </form>
-                        )
-                      ) : (
-                        <span className="admin-users__action-note">Disabled</span>
-                      )}
+                        ) : (
+                          <span className="admin-users__action-note">Disabled</span>
+                        )}
+
+                        {isLastActiveOwner ? (
+                          <span className="admin-users__action-note">
+                            Keep owner
+                          </span>
+                        ) : (
+                          <Link
+                            className="admin-link-button admin-users__remove-link"
+                            href={removeHref}
+                          >
+                            Remove user
+                          </Link>
+                        )}
+
+                        {currentAdminUser?.normalizedEmail === adminUser.normalizedEmail ? (
+                          <span className="admin-users__action-note">
+                            Signed in now
+                          </span>
+                        ) : null}
+                      </div>
                     </td>
                   </tr>
                 );

--- a/app/api/admin/users/remove/route.ts
+++ b/app/api/admin/users/remove/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { isCurrentAdminOwner } from "@/lib/admin-auth-server";
+import {
+  normalizeAdminEmail,
+  removeAdminUser,
+} from "@/lib/admin-user-store";
+
+export async function POST(request: Request) {
+  if (!(await isCurrentAdminOwner())) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const formData = await request.formData();
+  const normalizedEmailEntry = formData.get("normalizedEmail");
+  const confirmationEntry = formData.get("confirmation");
+  const normalizedEmail = normalizeAdminEmail(
+    typeof normalizedEmailEntry === "string" ? normalizedEmailEntry : "",
+  );
+  const confirmation =
+    typeof confirmationEntry === "string" ? confirmationEntry : "";
+
+  if (!normalizedEmail || confirmation !== "remove") {
+    return NextResponse.redirect(
+      new URL("/admin/users?error=remove-invalid", request.url),
+      303,
+    );
+  }
+
+  try {
+    await removeAdminUser(normalizedEmail);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "remove-invalid";
+
+    if (message === "Keep at least one active owner") {
+      return NextResponse.redirect(
+        new URL("/admin/users?error=keep-owner", request.url),
+        303,
+      );
+    }
+
+    return NextResponse.redirect(
+      new URL("/admin/users?error=remove-invalid", request.url),
+      303,
+    );
+  }
+
+  return NextResponse.redirect(
+    new URL("/admin/users?status=user-removed", request.url),
+    303,
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -678,6 +678,10 @@ a {
   cursor: pointer;
 }
 
+.admin-button--danger {
+  background: #6e1f1f;
+}
+
 .admin-link-button,
 .admin-card__link {
   display: inline-block;
@@ -791,6 +795,10 @@ a {
   color: var(--color-primary);
 }
 
+.admin-panel--warning {
+  max-width: 48rem;
+}
+
 .admin-attendees {
   padding-top: var(--space-6);
   border-top: 1px solid var(--color-border);
@@ -849,6 +857,13 @@ a {
   margin: 0;
 }
 
+.admin-users__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
 .admin-users__disable-button {
   border: 0;
   padding: 0;
@@ -856,9 +871,20 @@ a {
   cursor: pointer;
 }
 
+.admin-users__remove-link {
+  color: #6e1f1f;
+}
+
 .admin-users__disable-button:disabled {
   color: var(--color-accent);
   cursor: default;
+}
+
+.admin-users__confirmation-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
 }
 
 .admin-users__action-note {

--- a/lib/admin-user-store.ts
+++ b/lib/admin-user-store.ts
@@ -390,3 +390,36 @@ export async function disableAdminUser(
 
   return mapAdminUserRow(result.rows[0]);
 }
+
+export async function removeAdminUser(
+  normalizedEmail: string,
+): Promise<AdminUserRecord> {
+  const adminUser = await findAdminUserByNormalizedEmail(normalizedEmail);
+
+  if (!adminUser) {
+    throw new Error("Admin user not found");
+  }
+
+  if (adminUser.role === "owner" && adminUser.isActive && (await countActiveOwners()) <= 1) {
+    throw new Error("Keep at least one active owner");
+  }
+
+  const result = await getDb().query<AdminUserRow>(
+    `DELETE FROM ${ADMIN_USERS_TABLE}
+     WHERE normalized_email = $1
+     RETURNING
+      normalized_email,
+      email,
+      is_active,
+      password_hash,
+      role,
+      created_at`,
+    [normalizedEmail],
+  );
+
+  if (result.rowCount !== 1) {
+    throw new Error("Admin user not found");
+  }
+
+  return mapAdminUserRow(result.rows[0]);
+}


### PR DESCRIPTION
## Summary
Add owner-only safe permanent admin user removal with confirmation.

## Related Issue
Closes #79 

## Changes
- add owner-only remove user route
- add hard-delete support in admin user store
- add confirmation step before destructive removal
- keep last active owner protection intact
- keep delete visually distinct from disable

## Verification checklist
- [x] Owner can access `/admin/users`
- [x] Non-owner admin cannot remove users
- [x] Remove requires confirmation
- [x] Removed admin cannot log in afterward
- [x] Removed admin cannot access protected routes
- [x] Last active owner cannot be removed
- [x] Disable flow still works

## Notes
Hard delete is intentional for MVP. No recovery path included.