### PR TITLE
Issue 3-8: add admin access request flow

### DIFF
--- a/app/admin/(protected)/page.tsx
+++ b/app/admin/(protected)/page.tsx
@@ -63,6 +63,10 @@ export default async function AdminPage() {
             <Link className="admin-card__link" href="/admin/users">
               Manage Team Access
             </Link>
+            <br />
+            <Link className="admin-card__link" href="/admin/requests">
+              Review Access Requests
+            </Link>
           </section>
         ) : null}
 

--- a/app/admin/(protected)/requests/page.tsx
+++ b/app/admin/(protected)/requests/page.tsx
@@ -1,0 +1,195 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { isCurrentAdminOwner } from "@/lib/admin-auth-server";
+import {
+  listAdminAccessRequests,
+  type AdminAccessRequestRecord,
+} from "@/lib/admin-access-request-store";
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+type AdminRequestsPageProps = {
+  searchParams?: Promise<{
+    error?: string;
+    status?: string;
+  }>;
+};
+
+function formatCreatedAt(value: AdminAccessRequestRecord["createdAt"]) {
+  return dateFormatter.format(new Date(value));
+}
+
+function getFeedbackCopy(status?: string, error?: string) {
+  if (status === "approved") {
+    return {
+      tone: "status",
+      title: "Request approved",
+      body: "That request is now approved and the new admin account can sign in.",
+    };
+  }
+
+  if (status === "denied") {
+    return {
+      tone: "status",
+      title: "Request denied",
+      body: "That request has been marked as denied.",
+    };
+  }
+
+  if (error === "invalid") {
+    return {
+      tone: "error",
+      title: "That action could not be completed",
+      body: "Refresh the page and try again.",
+    };
+  }
+
+  return null;
+}
+
+export default async function AdminRequestsPage({
+  searchParams,
+}: AdminRequestsPageProps) {
+  if (!(await isCurrentAdminOwner())) {
+    redirect("/admin");
+  }
+
+  const [requests, resolvedSearchParams] = await Promise.all([
+    listAdminAccessRequests(),
+    searchParams,
+  ]);
+
+  const pendingRequests = requests.filter((request) => request.status === "pending");
+  const reviewedRequests = requests.filter((request) => request.status !== "pending");
+  const approvedRequests = requests.filter((request) => request.status === "approved");
+  const deniedRequests = requests.filter((request) => request.status === "denied");
+  const feedback = getFeedbackCopy(
+    resolvedSearchParams?.status,
+    resolvedSearchParams?.error,
+  );
+
+  return (
+    <section className="admin-page">
+      <section className="admin-hero">
+        <div className="admin-hero__content">
+          <p className="admin-page__eyebrow">Admin</p>
+          <h1 className="admin-page__title">Access requests</h1>
+          <p className="admin-page__lede">
+            Review pending requests for admin access and decide whether to
+            approve or deny them.
+          </p>
+        </div>
+
+        <Link className="admin-link-button" href="/admin">
+          Back to Dashboard
+        </Link>
+      </section>
+
+      <section className="admin-summary">
+        <div className="admin-summary__item">
+          <p className="admin-summary__label">Pending</p>
+          <p className="admin-summary__value">{pendingRequests.length}</p>
+        </div>
+        <div className="admin-summary__item">
+          <p className="admin-summary__label">Approved</p>
+          <p className="admin-summary__value">{approvedRequests.length}</p>
+        </div>
+        <div className="admin-summary__item">
+          <p className="admin-summary__label">Denied</p>
+          <p className="admin-summary__value">{deniedRequests.length}</p>
+        </div>
+      </section>
+
+      {feedback ? (
+        <section className={`admin-panel admin-panel--${feedback.tone}`}>
+          <h2>{feedback.title}</h2>
+          <p>{feedback.body}</p>
+        </section>
+      ) : null}
+
+      {pendingRequests.length === 0 ? (
+        <section className="admin-panel">
+          <h2>No pending requests</h2>
+          <p>New access requests will appear here when they are submitted.</p>
+        </section>
+      ) : (
+        <section className="admin-requests">
+          {pendingRequests.map((request) => (
+            <section className="admin-request-card" key={request.id}>
+              <div className="admin-request-card__details">
+                <p className="admin-card__eyebrow">Pending review</p>
+                <h2 className="admin-card__title">{request.fullName}</h2>
+                <p className="admin-card__body">{request.email}</p>
+                <p className="admin-card__body">
+                  {request.organization || "No organization provided"}
+                </p>
+                <p className="admin-card__status">
+                  Requested {formatCreatedAt(request.createdAt)}
+                </p>
+              </div>
+
+              <div className="admin-request-card__actions">
+                <form action="/api/admin/requests/approve" method="post">
+                  <input type="hidden" name="requestId" value={request.id} />
+                  <label className="admin-field" htmlFor={`password-${request.id}`}>
+                    <span>Set password</span>
+                    <input
+                      id={`password-${request.id}`}
+                      name="password"
+                      type="password"
+                      autoComplete="new-password"
+                      minLength={8}
+                      required
+                    />
+                  </label>
+                  <button className="admin-button" type="submit">
+                    Approve request
+                  </button>
+                </form>
+
+                <form action="/api/admin/requests/deny" method="post">
+                  <input type="hidden" name="requestId" value={request.id} />
+                  <button className="admin-link-button admin-users__remove-link" type="submit">
+                    Deny
+                  </button>
+                </form>
+              </div>
+            </section>
+          ))}
+        </section>
+      )}
+
+      {reviewedRequests.length > 0 ? (
+        <section className="admin-attendees">
+          <div className="admin-attendees__table-wrap">
+            <table className="admin-attendees__table">
+              <thead>
+                <tr>
+                  <th scope="col">Name</th>
+                  <th scope="col">Email</th>
+                  <th scope="col">Organization</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Submitted</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reviewedRequests.map((request) => (
+                  <tr key={request.id}>
+                    <td>{request.fullName}</td>
+                    <td>{request.email}</td>
+                    <td>{request.organization || "Not provided"}</td>
+                    <td>{request.status === "approved" ? "Approved" : "Denied"}</td>
+                    <td>{formatCreatedAt(request.createdAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ) : null}
+    </section>
+  );
+}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { isAdminAuthenticated } from "@/lib/admin-auth-server";
 
@@ -62,6 +63,12 @@ export default async function AdminLoginPage({
             Sign In
           </button>
         </form>
+
+        <p className="admin-request-access__links">
+          <Link className="admin-link-button" href="/admin/request-access">
+            Request admin access
+          </Link>
+        </p>
       </div>
     </section>
   );

--- a/app/admin/request-access/page.tsx
+++ b/app/admin/request-access/page.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+
+type AdminRequestAccessPageProps = {
+  searchParams?: Promise<{
+    error?: string;
+    status?: string;
+  }>;
+};
+
+function getFeedbackCopy(status?: string, error?: string) {
+  if (status === "pending") {
+    return {
+      title: "Pending review",
+      body: "Your request has been recorded. An owner can review it from the admin area.",
+    };
+  }
+
+  if (error === "access") {
+    return {
+      title: "That email already has access",
+      body: "Use the admin sign-in page with the credentials provided to you.",
+    };
+  }
+
+  if (error === "invalid") {
+    return {
+      title: "That request could not be submitted",
+      body: "Check your details and try again.",
+    };
+  }
+
+  return null;
+}
+
+export default async function AdminRequestAccessPage({
+  searchParams,
+}: AdminRequestAccessPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const feedback = getFeedbackCopy(
+    resolvedSearchParams?.status,
+    resolvedSearchParams?.error,
+  );
+
+  return (
+    <section className="admin-login-page">
+      <div className="admin-login-card">
+        <p className="admin-login-card__eyebrow">Admin</p>
+        <h1 className="admin-login-card__title">Request admin access.</h1>
+        <p className="admin-login-card__lede">
+          Share a few details so the owner can review your request for access to
+          the internal operator area.
+        </p>
+
+        {feedback ? (
+          <div className="admin-request-access__feedback">
+            <p className="admin-login-card__error">{feedback.title}</p>
+            <p className="admin-login-card__lede">{feedback.body}</p>
+          </div>
+        ) : null}
+
+        <form action="/api/admin/request-access" method="post">
+          <label className="admin-field" htmlFor="fullName">
+            <span>Full name</span>
+            <input id="fullName" name="fullName" type="text" required />
+          </label>
+
+          <label className="admin-field" htmlFor="email">
+            <span>Email</span>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+            />
+          </label>
+
+          <label className="admin-field" htmlFor="organization">
+            <span>Organization (optional)</span>
+            <input id="organization" name="organization" type="text" />
+          </label>
+
+          <button className="admin-button admin-button--full" type="submit">
+            Request admin access
+          </button>
+        </form>
+
+        <p className="admin-request-access__links">
+          <Link className="admin-link-button" href="/admin/login">
+            Back to admin sign in
+          </Link>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/app/api/admin/request-access/route.ts
+++ b/app/api/admin/request-access/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { createAdminAccessRequest } from "@/lib/admin-access-request-store";
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const fullName = formData.get("fullName");
+  const email = formData.get("email");
+  const organization = formData.get("organization");
+
+  if (typeof fullName !== "string" || typeof email !== "string") {
+    return NextResponse.redirect(
+      new URL("/admin/request-access?error=invalid", request.url),
+      303,
+    );
+  }
+
+  try {
+    const status = await createAdminAccessRequest({
+      email,
+      fullName,
+      organization: typeof organization === "string" ? organization : "",
+    });
+
+    if (status === "already-has-access") {
+      return NextResponse.redirect(
+        new URL("/admin/request-access?error=access", request.url),
+        303,
+      );
+    }
+
+    if (status === "pending") {
+      return NextResponse.redirect(
+        new URL("/admin/request-access?status=pending", request.url),
+        303,
+      );
+    }
+  } catch {
+    return NextResponse.redirect(
+      new URL("/admin/request-access?error=invalid", request.url),
+      303,
+    );
+  }
+
+  return NextResponse.redirect(
+    new URL("/admin/request-access?status=pending", request.url),
+    303,
+  );
+}

--- a/app/api/admin/requests/approve/route.ts
+++ b/app/api/admin/requests/approve/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { isCurrentAdminOwner } from "@/lib/admin-auth-server";
+import { approveAdminAccessRequest } from "@/lib/admin-access-request-store";
+
+export async function POST(request: Request) {
+  if (!(await isCurrentAdminOwner())) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const formData = await request.formData();
+  const requestIdValue = formData.get("requestId");
+  const password = formData.get("password");
+  const requestId =
+    typeof requestIdValue === "string" ? Number.parseInt(requestIdValue, 10) : NaN;
+
+  if (!Number.isInteger(requestId) || typeof password !== "string" || !password) {
+    return NextResponse.redirect(
+      new URL("/admin/requests?error=invalid", request.url),
+      303,
+    );
+  }
+
+  try {
+    await approveAdminAccessRequest({
+      password,
+      requestId,
+    });
+  } catch {
+    return NextResponse.redirect(
+      new URL("/admin/requests?error=invalid", request.url),
+      303,
+    );
+  }
+
+  return NextResponse.redirect(
+    new URL("/admin/requests?status=approved", request.url),
+    303,
+  );
+}

--- a/app/api/admin/requests/deny/route.ts
+++ b/app/api/admin/requests/deny/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { isCurrentAdminOwner } from "@/lib/admin-auth-server";
+import { denyAdminAccessRequest } from "@/lib/admin-access-request-store";
+
+export async function POST(request: Request) {
+  if (!(await isCurrentAdminOwner())) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const formData = await request.formData();
+  const requestIdValue = formData.get("requestId");
+  const requestId =
+    typeof requestIdValue === "string" ? Number.parseInt(requestIdValue, 10) : NaN;
+
+  if (!Number.isInteger(requestId)) {
+    return NextResponse.redirect(
+      new URL("/admin/requests?error=invalid", request.url),
+      303,
+    );
+  }
+
+  try {
+    await denyAdminAccessRequest(requestId);
+  } catch {
+    return NextResponse.redirect(
+      new URL("/admin/requests?error=invalid", request.url),
+      303,
+    );
+  }
+
+  return NextResponse.redirect(
+    new URL("/admin/requests?status=denied", request.url),
+    303,
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -799,9 +799,32 @@ a {
   max-width: 48rem;
 }
 
+.admin-request-access__feedback,
+.admin-request-access__links {
+  margin-top: var(--space-6);
+}
+
 .admin-attendees {
   padding-top: var(--space-6);
   border-top: 1px solid var(--color-border);
+}
+
+.admin-requests {
+  display: grid;
+  gap: var(--space-8);
+  margin-bottom: var(--space-8);
+}
+
+.admin-request-card {
+  display: grid;
+  gap: var(--space-6);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+
+.admin-request-card__actions {
+  display: grid;
+  gap: var(--space-6);
 }
 
 .admin-attendees__table-wrap {

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -4,6 +4,9 @@ export async function register() {
   }
 
   const { initializeAdminUserStore } = await import("@/lib/admin-user-store");
+  const { initializeAdminAccessRequestStore } = await import(
+    "@/lib/admin-access-request-store"
+  );
   const { initializeRegistrationEmailStore } = await import(
     "@/lib/registration-email-store"
   );
@@ -11,6 +14,7 @@ export async function register() {
     "@/lib/registration-store"
   );
 
+  await initializeAdminAccessRequestStore();
   await initializeAdminUserStore();
   await initializeRegistrationEmailStore();
   await initializeRegistrationStore();

--- a/lib/admin-access-request-store.ts
+++ b/lib/admin-access-request-store.ts
@@ -1,0 +1,303 @@
+import { getDb } from "@/lib/db";
+import {
+  ADMIN_USERS_TABLE,
+  createAdminPasswordHash,
+  findAdminUserByNormalizedEmail,
+  normalizeAdminEmail,
+} from "@/lib/admin-user-store";
+
+const ADMIN_ACCESS_REQUESTS_TABLE = "admin_access_requests";
+const ADMIN_ACCESS_REQUESTS_PENDING_INDEX =
+  "admin_access_requests_pending_email_idx";
+const ADMIN_ACCESS_REQUESTS_STATUS_CONSTRAINT =
+  "admin_access_requests_status_check";
+
+let adminAccessRequestsTablePromise: Promise<void> | null = null;
+
+type AdminAccessRequestRow = {
+  created_at: string;
+  email: string;
+  full_name: string;
+  id: number;
+  normalized_email: string;
+  organization: string | null;
+  status: string;
+};
+
+export const ADMIN_ACCESS_REQUEST_STATUSES = [
+  "pending",
+  "approved",
+  "denied",
+] as const;
+
+export type AdminAccessRequestStatus =
+  (typeof ADMIN_ACCESS_REQUEST_STATUSES)[number];
+
+export type AdminAccessRequestRecord = {
+  createdAt: string;
+  email: string;
+  fullName: string;
+  id: number;
+  normalizedEmail: string;
+  organization: string | null;
+  status: AdminAccessRequestStatus;
+};
+
+export type CreateAdminAccessRequestStatus =
+  | "created"
+  | "already-has-access"
+  | "pending";
+
+function parseAdminAccessRequestStatus(
+  value: unknown,
+): AdminAccessRequestStatus | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  return (
+    ADMIN_ACCESS_REQUEST_STATUSES.find((status) => status === value) ?? null
+  );
+}
+
+function mapAdminAccessRequestRow(
+  row: AdminAccessRequestRow,
+): AdminAccessRequestRecord {
+  const status = parseAdminAccessRequestStatus(row.status);
+
+  if (!status) {
+    throw new Error(`Invalid admin access request status for ${row.id}`);
+  }
+
+  return {
+    createdAt: row.created_at,
+    email: row.email,
+    fullName: row.full_name,
+    id: row.id,
+    normalizedEmail: row.normalized_email,
+    organization: row.organization,
+    status,
+  };
+}
+
+export async function initializeAdminAccessRequestStore() {
+  if (!adminAccessRequestsTablePromise) {
+    adminAccessRequestsTablePromise = getDb()
+      .query(`CREATE TABLE IF NOT EXISTS ${ADMIN_ACCESS_REQUESTS_TABLE} (
+        id BIGSERIAL PRIMARY KEY,
+        full_name TEXT NOT NULL,
+        email TEXT NOT NULL,
+        normalized_email TEXT NOT NULL,
+        organization TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )`)
+      .then(() =>
+        getDb().query(
+          `DO $$
+          BEGIN
+            IF NOT EXISTS (
+              SELECT 1
+              FROM pg_constraint
+              WHERE conname = '${ADMIN_ACCESS_REQUESTS_STATUS_CONSTRAINT}'
+            ) THEN
+              ALTER TABLE ${ADMIN_ACCESS_REQUESTS_TABLE}
+              ADD CONSTRAINT ${ADMIN_ACCESS_REQUESTS_STATUS_CONSTRAINT}
+              CHECK (status IN ('pending', 'approved', 'denied'));
+            END IF;
+          END $$;`,
+        ),
+      )
+      .then(() =>
+        getDb().query(
+          `CREATE UNIQUE INDEX IF NOT EXISTS ${ADMIN_ACCESS_REQUESTS_PENDING_INDEX}
+           ON ${ADMIN_ACCESS_REQUESTS_TABLE} (normalized_email)
+           WHERE status = 'pending'`,
+        ),
+      )
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        adminAccessRequestsTablePromise = null;
+        throw error;
+      });
+  }
+
+  await adminAccessRequestsTablePromise;
+}
+
+export async function createAdminAccessRequest({
+  email,
+  fullName,
+  organization,
+}: {
+  email: string;
+  fullName: string;
+  organization?: string;
+}): Promise<CreateAdminAccessRequestStatus> {
+  const normalizedEmail = normalizeAdminEmail(email);
+  const trimmedFullName = fullName.trim();
+
+  if (!trimmedFullName) {
+    throw new Error("Full name is required");
+  }
+
+  if (!normalizedEmail) {
+    throw new Error("Email is required");
+  }
+
+  if (await findAdminUserByNormalizedEmail(normalizedEmail)) {
+    return "already-has-access";
+  }
+
+  try {
+    await getDb().query(
+      `INSERT INTO ${ADMIN_ACCESS_REQUESTS_TABLE} (
+        full_name,
+        email,
+        normalized_email,
+        organization,
+        status
+      ) VALUES ($1, $2, $3, $4, 'pending')`,
+      [trimmedFullName, email.trim(), normalizedEmail, organization?.trim() || null],
+    );
+
+    return "created";
+  } catch (error) {
+    const pgError = error as { code?: string };
+
+    if (pgError.code === "23505") {
+      return "pending";
+    }
+
+    throw error;
+  }
+}
+
+export async function listAdminAccessRequests(): Promise<
+  AdminAccessRequestRecord[]
+> {
+  const result = await getDb().query<AdminAccessRequestRow>(
+    `SELECT
+      id,
+      full_name,
+      email,
+      normalized_email,
+      organization,
+      status,
+      created_at
+     FROM ${ADMIN_ACCESS_REQUESTS_TABLE}
+     ORDER BY
+      CASE status
+        WHEN 'pending' THEN 0
+        WHEN 'approved' THEN 1
+        ELSE 2
+      END,
+      created_at DESC`,
+  );
+
+  return result.rows.map(mapAdminAccessRequestRow);
+}
+
+export async function approveAdminAccessRequest({
+  password,
+  requestId,
+}: {
+  password: string;
+  requestId: number;
+}) {
+  if (!password) {
+    throw new Error("Password is required");
+  }
+
+  const client = await getDb().connect();
+
+  try {
+    await client.query("BEGIN");
+
+    const requestResult = await client.query<AdminAccessRequestRow>(
+      `SELECT
+        id,
+        full_name,
+        email,
+        normalized_email,
+        organization,
+        status,
+        created_at
+       FROM ${ADMIN_ACCESS_REQUESTS_TABLE}
+       WHERE id = $1
+       FOR UPDATE`,
+      [requestId],
+    );
+
+    if (requestResult.rowCount !== 1) {
+      throw new Error("Request not found");
+    }
+
+    const accessRequest = mapAdminAccessRequestRow(requestResult.rows[0]);
+
+    if (accessRequest.status !== "pending") {
+      throw new Error("Request is no longer pending");
+    }
+
+    const existingAdminResult = await client.query(
+      `SELECT 1
+       FROM ${ADMIN_USERS_TABLE}
+       WHERE normalized_email = $1`,
+      [accessRequest.normalizedEmail],
+    );
+
+    if (existingAdminResult.rowCount === 0) {
+      const passwordHash = await createAdminPasswordHash(password);
+
+      await client.query(
+        `INSERT INTO ${ADMIN_USERS_TABLE} (
+          normalized_email,
+          email,
+          password_hash,
+          is_active,
+          role
+        ) VALUES ($1, $2, $3, TRUE, 'admin')`,
+        [accessRequest.normalizedEmail, accessRequest.email, passwordHash],
+      );
+    }
+
+    await client.query(
+      `UPDATE ${ADMIN_ACCESS_REQUESTS_TABLE}
+       SET status = 'approved'
+       WHERE id = $1`,
+      [requestId],
+    );
+
+    await client.query("COMMIT");
+    return accessRequest;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function denyAdminAccessRequest(requestId: number) {
+  const result = await getDb().query<AdminAccessRequestRow>(
+    `UPDATE ${ADMIN_ACCESS_REQUESTS_TABLE}
+     SET status = 'denied'
+     WHERE id = $1
+       AND status = 'pending'
+     RETURNING
+      id,
+      full_name,
+      email,
+      normalized_email,
+      organization,
+      status,
+      created_at`,
+    [requestId],
+  );
+
+  if (result.rowCount !== 1) {
+    throw new Error("Request not found");
+  }
+
+  return mapAdminAccessRequestRow(result.rows[0]);
+}

--- a/lib/admin-user-store.ts
+++ b/lib/admin-user-store.ts
@@ -2,7 +2,7 @@ import { randomBytes, scrypt as nodeScrypt, timingSafeEqual } from "node:crypto"
 import { promisify } from "node:util";
 import { getDb } from "@/lib/db";
 
-const ADMIN_USERS_TABLE = "admin_users";
+export const ADMIN_USERS_TABLE = "admin_users";
 const SCRYPT_KEY_LENGTH = 64;
 const scrypt = promisify(nodeScrypt);
 
@@ -76,7 +76,7 @@ function getStoredHashParts(passwordHash: string) {
   };
 }
 
-async function hashPassword(password: string) {
+export async function createAdminPasswordHash(password: string) {
   const salt = randomBytes(16).toString("hex");
   const derivedKey = (await scrypt(
     password,
@@ -246,7 +246,7 @@ export async function upsertAdminUser({
     throw new Error("Admin role must be owner or admin");
   }
 
-  const passwordHash = await hashPassword(password);
+  const passwordHash = await createAdminPasswordHash(password);
   const result = await getDb().query<AdminUserRow>(
     `INSERT INTO ${ADMIN_USERS_TABLE} (
       normalized_email,

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,7 +7,7 @@ import {
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  if (pathname === "/admin/login") {
+  if (pathname === "/admin/login" || pathname === "/admin/request-access") {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary
Add a simple admin access request flow with owner review and approval/denial.

## Related Issue
Closes #76 

## Changes
- add public `/admin/request-access` form
- add durable `admin_access_requests` storage
- add owner-only `/admin/requests` review page
- add approve and deny actions for pending requests
- create admin users on approval using existing user flow
- allow public request route through proxy protection

## Verification checklist
- [x] Public request form loads and submits
- [x] Requests are stored in DB
- [x] Owner can access `/admin/requests`
- [x] Owner can approve a request
- [x] Owner can deny a request
- [x] Approved request creates an active admin user
- [x] Approved user can log in
- [x] Non-owner cannot manage requests
- [x] Existing admin behavior remains unchanged

## Notes
For MVP, the owner sets the approved user password during approval. Password handoff remains manual.