### PR TITLE
Issue 4-1: wire Stripe checkout session flow

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,89 +1,54 @@
 import { NextResponse } from "next/server";
-import {
-  buildRegistrationDraft,
-  REGISTRATION_DRAFT_COOKIE,
-  getRegistrationDraftCookieOptions,
-  hasCheckoutReadyDraft,
-  normalizeRegistrationValues,
-  readRegistrationDraft,
-  serializeRegistrationDraft,
-} from "@/app/register/registration";
-import { EMPTY_REGISTRATION_FORM_VALUES } from "@/app/register/types";
-import { getStripeCheckoutConfig, buildStripeCheckoutSessionPayload } from "@/lib/stripe-checkout";
+import { createStripeClient } from "@/app/lib/stripe";
+import { getStripeCheckoutConfig } from "@/lib/stripe-checkout";
 
-function redirectToRegister(request: Request, search: Record<string, string>) {
-  const url = new URL("/register", request.url);
+type CheckoutRequestBody = {
+  email?: unknown;
+};
 
-  for (const [key, value] of Object.entries(search)) {
-    url.searchParams.set(key, value);
-  }
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as CheckoutRequestBody;
+    const email =
+      typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
 
-  return NextResponse.redirect(url, 303);
-}
-
-export async function POST(request: Request) {
-  const formData = await request.formData();
-  const submittedRegistrationFields = Object.keys(
-    EMPTY_REGISTRATION_FORM_VALUES,
-  ).some((fieldName) => formData.has(fieldName));
-  const submittedValues = normalizeRegistrationValues(formData);
-  const submittedDraft = hasCheckoutReadyDraft(submittedValues)
-    ? buildRegistrationDraft(submittedValues)
-    : null;
-
-  if (submittedRegistrationFields && !submittedDraft) {
-    return redirectToRegister(request, {
-      error: "draft",
-      step: "payment",
-    });
-  }
-
-  const existingDraft = await readRegistrationDraft();
-  const draft = submittedDraft ?? existingDraft;
-
-  if (!draft || !hasCheckoutReadyDraft(draft)) {
-    return redirectToRegister(request, {
-      error: "draft",
-      step: "payment",
-    });
-  }
-
-  const stripeConfig = getStripeCheckoutConfig();
-
-  if (!stripeConfig) {
-    const response = redirectToRegister(request, {
-      mode: "stub",
-      step: "payment",
-    });
-
-    if (submittedDraft) {
-      response.cookies.set(
-        REGISTRATION_DRAFT_COOKIE,
-        serializeRegistrationDraft(submittedDraft),
-        getRegistrationDraftCookieOptions(),
+    if (!email) {
+      return NextResponse.json(
+        { error: "A registration email is required to start checkout." },
+        { status: 400 },
       );
     }
 
-    return response;
-  }
+    const config = getStripeCheckoutConfig();
 
-  const sessionPayload = buildStripeCheckoutSessionPayload(draft, stripeConfig);
-  void sessionPayload;
-  // Stripe session creation is intentionally deferred until real credentials
-  // and the SDK are introduced in a later issue.
+    if (!config) {
+      return NextResponse.json(
+        { error: "Stripe checkout is not configured for this environment." },
+        { status: 503 },
+      );
+    }
 
-  const response = redirectToRegister(request, {
-    mode: "stripe-ready",
-    step: "payment",
-  });
+    const stripe = createStripeClient(config.secretKey);
 
-  if (submittedDraft) {
-    response.cookies.set(
-      REGISTRATION_DRAFT_COOKIE,
-      serializeRegistrationDraft(submittedDraft),
-      getRegistrationDraftCookieOptions(),
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      line_items: [
+        {
+          price: config.priceId,
+          quantity: 1,
+        },
+      ],
+      customer_email: email,
+      success_url: `${config.appUrl}/confirmation?mode=checkout`,
+      cancel_url: `${config.appUrl}/register/success`,
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (err) {
+    console.error("Stripe checkout error:", err);
+    return NextResponse.json(
+      { error: "Unable to create checkout session." },
+      { status: 500 },
     );
   }
-
-  return response;
 }

--- a/app/lib/stripe.ts
+++ b/app/lib/stripe.ts
@@ -1,0 +1,5 @@
+import Stripe from "stripe";
+
+export function createStripeClient(secretKey: string) {
+  return new Stripe(secretKey);
+}

--- a/app/register/success/checkout-button.tsx
+++ b/app/register/success/checkout-button.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from "react";
+
+type CheckoutButtonProps = {
+  email: string;
+};
+
+export function CheckoutButton({ email }: CheckoutButtonProps) {
+  const [isPending, setIsPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleCheckout() {
+    setIsPending(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch("/api/checkout", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      });
+
+      const payload = (await response.json()) as {
+        error?: string;
+        url?: string;
+      };
+
+      if (!response.ok || !payload.url) {
+        setErrorMessage(
+          payload.error ?? "We couldn't start checkout right now. Please try again.",
+        );
+        return;
+      }
+
+      window.location.assign(payload.url);
+    } catch {
+      setErrorMessage("We couldn't start checkout right now. Please try again.");
+    } finally {
+      setIsPending(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        className="register-success-actions__primary"
+        disabled={isPending}
+        onClick={handleCheckout}
+        type="button"
+      >
+        {isPending ? "Redirecting to Payment..." : "Continue to Payment"}
+      </button>
+      {errorMessage ? (
+        <p className="register-success-section__note" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/app/register/success/page.tsx
+++ b/app/register/success/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { readRegistrationDraft } from "../registration";
+import { CheckoutButton } from "./checkout-button";
 
 export default async function RegisterSuccessPage() {
   const draft = await readRegistrationDraft();
@@ -55,11 +56,7 @@ export default async function RegisterSuccessPage() {
           </p>
         </div>
         <div className="register-success-actions__links">
-          <form action="/api/checkout" method="post">
-            <button className="register-success-actions__primary" type="submit">
-              Continue to Payment
-            </button>
-          </form>
+          <CheckoutButton email={draft.email} />
           <Link className="register-success-actions__secondary" href="/register">
             Edit Registration
           </Link>

--- a/lib/stripe-checkout.ts
+++ b/lib/stripe-checkout.ts
@@ -1,21 +1,7 @@
-import type { RegistrationDraft } from "@/app/register/types";
-
 type StripeCheckoutConfig = {
   appUrl: string;
   priceId: string;
   secretKey: string;
-};
-
-type StripeCheckoutSessionPayload = {
-  cancel_url: string;
-  customer_email: string;
-  line_items: Array<{
-    price: string;
-    quantity: number;
-  }>;
-  metadata: Record<string, string>;
-  mode: "payment";
-  success_url: string;
 };
 
 function normalizeAppUrl(value: string) {
@@ -35,30 +21,5 @@ export function getStripeCheckoutConfig(): StripeCheckoutConfig | null {
     appUrl: normalizeAppUrl(appUrl),
     priceId,
     secretKey,
-  };
-}
-
-export function buildStripeCheckoutSessionPayload(
-  draft: RegistrationDraft,
-  config: StripeCheckoutConfig,
-): StripeCheckoutSessionPayload {
-  return {
-    cancel_url: `${config.appUrl}/register?step=payment&mode=cancelled`,
-    customer_email: draft.email,
-    line_items: [
-      {
-        price: config.priceId,
-        quantity: 1,
-      },
-    ],
-    metadata: {
-      attendeeEmail: draft.email,
-      attendeeName: `${draft.firstName} ${draft.lastName}`.trim(),
-      organization: draft.organization,
-      role: draft.role,
-      submittedAt: draft.submittedAt,
-    },
-    mode: "payment",
-    success_url: `${config.appUrl}/confirmation?mode=checkout`,
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "next": "16.2.3",
         "pg": "^8.20.0",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "stripe": "^22.0.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1525,7 +1526,7 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5879,6 +5880,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.0.1.tgz",
+      "integrity": "sha512-Yw764pZ6s8Xu4CtUZdD5uWOkw6gc9xzO9OKylCuj1gMhMDLbyGbDtaPNNSFE4mB6njYSHESYIVbF1iIzUfAl2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -6186,7 +6204,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "next": "16.2.3",
     "pg": "^8.20.0",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "stripe": "^22.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
Wire the Stripe checkout flow from the canonical `/register/success` step.

## Related Issue
Closes #37 

## Changes
- added real Stripe Checkout Session creation in `/api/checkout`
- added Stripe client/config seam for test-mode checkout
- made `/register/success` the working payment trigger
- added a small client checkout button that posts JSON and redirects to Stripe
- removed stale unused Stripe payload helper to reduce seam drift

## Verification checklist
- [x] Fresh registration redirects to `/register/success`
- [x] Success page shows registration email
- [x] Continue to Payment redirects to Stripe-hosted Checkout
- [x] Test checkout completes successfully
- [x] Return flow lands on confirmation path
- [x] No webhook/payment-verification logic added

## Notes
Smoke test passed in test mode. This issue only establishes Stripe checkout handoff, not payment truth.