### PR TITLE
Issue 4-2: make Stripe payment persistence idempotent

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createStripeClient } from "@/app/lib/stripe";
+import { getRegistrationByNormalizedEmail } from "@/lib/registration-store";
 import { getStripeCheckoutConfig } from "@/lib/stripe-checkout";
 
 type CheckoutRequestBody = {
@@ -16,6 +17,15 @@ export async function POST(req: Request) {
       return NextResponse.json(
         { error: "A registration email is required to start checkout." },
         { status: 400 },
+      );
+    }
+
+    const registration = await getRegistrationByNormalizedEmail(email);
+
+    if (!registration) {
+      return NextResponse.json(
+        { error: "A saved registration is required before checkout can begin." },
+        { status: 404 },
       );
     }
 
@@ -39,6 +49,9 @@ export async function POST(req: Request) {
         },
       ],
       customer_email: email,
+      metadata: {
+        registration_email: registration.normalizedEmail,
+      },
       success_url: `${config.appUrl}/confirmation?mode=checkout`,
       cancel_url: `${config.appUrl}/register/success`,
     });

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,0 +1,145 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import { createStripeClient } from "@/app/lib/stripe";
+import { createPaymentRecord } from "@/lib/payment-store";
+import { getRegistrationByNormalizedEmail } from "@/lib/registration-store";
+
+export const runtime = "nodejs";
+
+function getStripeWebhookConfig() {
+  const secretKey = process.env.STRIPE_SECRET_KEY?.trim();
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET?.trim();
+
+  if (!secretKey || !webhookSecret) {
+    return null;
+  }
+
+  return {
+    secretKey,
+    webhookSecret,
+  };
+}
+
+function getRegistrationEmail(session: Stripe.Checkout.Session) {
+  const registrationEmail = session.metadata?.registration_email
+    ?.trim()
+    .toLowerCase();
+
+  return registrationEmail || null;
+}
+
+function getPaymentIntentId(
+  paymentIntent: Stripe.Checkout.Session["payment_intent"],
+) {
+  return typeof paymentIntent === "string"
+    ? paymentIntent
+    : paymentIntent?.id ?? null;
+}
+
+function getAmountTotal(session: Stripe.Checkout.Session) {
+  return typeof session.amount_total === "number" ? session.amount_total : null;
+}
+
+export async function POST(req: Request) {
+  const config = getStripeWebhookConfig();
+
+  if (!config) {
+    return NextResponse.json(
+      { error: "Stripe webhook is not configured for this environment." },
+      { status: 503 },
+    );
+  }
+
+  const signature = req.headers.get("stripe-signature");
+
+  if (!signature) {
+    return NextResponse.json(
+      { error: "Missing Stripe signature." },
+      { status: 400 },
+    );
+  }
+
+  const rawBody = await req.text();
+  const stripe = createStripeClient(config.secretKey);
+
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(
+      rawBody,
+      signature,
+      config.webhookSecret,
+    );
+  } catch (error) {
+    console.error("Stripe webhook signature verification failed:", error);
+    return NextResponse.json({ error: "Invalid Stripe signature." }, { status: 400 });
+  }
+
+  if (event.type !== "checkout.session.completed") {
+    return NextResponse.json({ received: true });
+  }
+
+  try {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const registrationEmail = getRegistrationEmail(session);
+    const amountTotal = getAmountTotal(session);
+    const currency = session.currency?.trim().toLowerCase() ?? "";
+
+    if (!registrationEmail) {
+      console.error("Stripe webhook missing registration metadata", {
+        eventId: event.id,
+        sessionId: session.id,
+      });
+      return NextResponse.json(
+        { error: "Missing registration metadata." },
+        { status: 400 },
+      );
+    }
+
+    if (amountTotal === null || !currency) {
+      console.error("Stripe webhook missing payment totals", {
+        amountTotal,
+        currency,
+        eventId: event.id,
+        sessionId: session.id,
+      });
+      return NextResponse.json(
+        { error: "Missing payment totals." },
+        { status: 400 },
+      );
+    }
+
+    const registration =
+      await getRegistrationByNormalizedEmail(registrationEmail);
+
+    if (!registration) {
+      console.error("Stripe webhook registration lookup failed", {
+        eventId: event.id,
+        registrationEmail,
+        sessionId: session.id,
+      });
+      return NextResponse.json(
+        { error: "Registration not found for payment event." },
+        { status: 400 },
+      );
+    }
+
+    await createPaymentRecord({
+      amountTotal,
+      currency,
+      paymentStatus: session.payment_status ?? "unpaid",
+      registrationEmail: registration.normalizedEmail,
+      stripeCheckoutSessionId: session.id,
+      stripeEventId: event.id,
+      stripePaymentIntentId: getPaymentIntentId(session.payment_intent),
+    });
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    console.error("Stripe webhook handling failed:", error);
+    return NextResponse.json(
+      { error: "Unable to process Stripe webhook." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/confirmation/page.tsx
+++ b/app/confirmation/page.tsx
@@ -26,8 +26,8 @@ export default async function ConfirmationPage({
         </h1>
         <p className="confirmation-page__lede">
           {fromCheckout
-            ? "Your checkout flow has reached its confirmation destination. Final live payment verification will be connected when Stripe is fully enabled."
-            : "This page is the public confirmation destination for the summit flow. It is ready for the live checkout return, while staying clear that payment confirmation is not active in this environment."}
+            ? "Your checkout flow has reached its confirmation destination. Payment verification is handled server-side via Stripe webhooks after checkout returns."
+            : "This page is the public confirmation destination for the summit flow. It supports the live checkout return while staying clear that this page itself is not the payment source of truth."}
         </p>
 
         <div className="confirmation-status">
@@ -38,8 +38,8 @@ export default async function ConfirmationPage({
           </p>
           <p className="confirmation-status__body">
             {fromCheckout
-              ? "You are seeing the live-ready confirmation structure used after checkout returns. This confirms the route and page shape, not a verified payment result."
-              : "Stripe is not live yet, so this page does not claim a completed payment. It exists to complete the public flow shape and support the real return step later with minimal change."}
+              ? "You are seeing the public page used after checkout returns. Verified Stripe webhook events, not this redirect, determine whether payment is recorded."
+              : "This route completes the public flow shape without claiming payment success from the browser alone."}
           </p>
         </div>
       </div>
@@ -50,16 +50,16 @@ export default async function ConfirmationPage({
           <ol className="confirmation-list">
             <li>Your registration and checkout path can end here cleanly.</li>
             <li>Summit details and follow-up instructions can be added here later.</li>
-            <li>Live payment confirmation can plug into this structure once Stripe is enabled.</li>
+            <li>Payment records are created only after Stripe sends a verified webhook event.</li>
           </ol>
         </section>
 
         <section className="confirmation-section">
           <h2>What this page means today</h2>
           <p>
-            This is a calm handoff point for the current demo and stub flow. It
-            shows the intended post-commit destination without overstating what
-            has happened behind the scenes.
+            This is a calm handoff point for the live checkout return. The page
+            gives the user a stable destination without overstating what the
+            browser alone can prove.
           </p>
           <p className="confirmation-section__note">
             Details, attendance instructions, or payment-specific messaging can

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,17 @@
+# Environment Variables
+
+## Required (Local + Vercel)
+
+- STRIPE_SECRET_KEY
+- STRIPE_PRICE_ID
+- NEXT_PUBLIC_BASE_URL
+
+## Webhooks (4-2)
+
+- STRIPE_WEBHOOK_SECRET
+
+## Rules
+
+- Never expose secret keys client-side
+- Vercel must mirror .env.local
+- Missing env = fail fast

--- a/docs/PAYMENT_FLOW.md
+++ b/docs/PAYMENT_FLOW.md
@@ -1,0 +1,49 @@
+# Payment Flow — Settled on the Field
+
+## Current Flow (4-1)
+
+Landing → Summit → Register → Success → Stripe Checkout → Confirmation
+
+System does NOT trust payment yet.
+
+---
+
+## Target Flow (4-2)
+
+User submits registration
+→ Stripe Checkout
+→ Stripe webhook fires
+→ System verifies event
+→ Payment recorded
+→ Registration marked paid
+→ Confirmation becomes truthful
+
+---
+
+## Source of Truth
+
+Stripe webhook (checkout.session.completed)
+
+---
+
+## Non-Truth Signals
+
+- redirect success URL
+- client-side state
+- query params
+
+---
+
+## Risks
+
+- duplicate webhook events
+- missing signature verification
+- race conditions between registration and payment
+
+---
+
+## Invariants
+
+- Never trust client for payment
+- Only trust verified Stripe events
+- Payment must link to a registration

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -13,9 +13,11 @@ export async function register() {
   const { initializeRegistrationStore } = await import(
     "@/lib/registration-store"
   );
+  const { initializePaymentStore } = await import("@/lib/payment-store");
 
   await initializeAdminAccessRequestStore();
   await initializeAdminUserStore();
   await initializeRegistrationEmailStore();
   await initializeRegistrationStore();
+  await initializePaymentStore();
 }

--- a/lib/payment-store.ts
+++ b/lib/payment-store.ts
@@ -1,0 +1,168 @@
+import { getDb } from "@/lib/db";
+
+const PAYMENTS_TABLE = "payments";
+let paymentsTablePromise: Promise<void> | null = null;
+
+export type PaymentRecord = {
+  amountTotal: number;
+  createdAt: string;
+  currency: string;
+  paymentStatus: string;
+  registrationEmail: string;
+  stripeCheckoutSessionId: string;
+  stripeEventId: string;
+  stripePaymentIntentId: string | null;
+  updatedAt: string;
+};
+
+type CreatePaymentRecordInput = {
+  amountTotal: number;
+  currency: string;
+  paymentStatus: string;
+  registrationEmail: string;
+  stripeCheckoutSessionId: string;
+  stripeEventId: string;
+  stripePaymentIntentId: string | null;
+};
+
+type PaymentRow = {
+  amount_total: number;
+  created_at: string;
+  currency: string;
+  payment_status: string;
+  registration_id: string;
+  stripe_checkout_session_id: string;
+  stripe_event_id: string;
+  stripe_payment_intent_id: string | null;
+  updated_at: string;
+};
+
+export async function initializePaymentStore() {
+  if (!paymentsTablePromise) {
+    paymentsTablePromise = getDb()
+      .query(
+        `CREATE TABLE IF NOT EXISTS ${PAYMENTS_TABLE} (
+          registration_id TEXT NOT NULL REFERENCES registrations(normalized_email),
+          stripe_checkout_session_id TEXT NOT NULL UNIQUE,
+          stripe_event_id TEXT NOT NULL UNIQUE,
+          stripe_payment_intent_id TEXT,
+          amount_total INTEGER NOT NULL,
+          currency TEXT NOT NULL,
+          payment_status TEXT NOT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )`,
+      )
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        paymentsTablePromise = null;
+        throw error;
+      });
+  }
+
+  await paymentsTablePromise;
+}
+
+export async function createPaymentRecord(
+  input: CreatePaymentRecordInput,
+): Promise<PaymentRecord> {
+  const result = await getDb().query<PaymentRow>(
+    `WITH inserted AS (
+      INSERT INTO ${PAYMENTS_TABLE} (
+        registration_id,
+        stripe_checkout_session_id,
+        stripe_event_id,
+        stripe_payment_intent_id,
+        amount_total,
+        currency,
+        payment_status,
+        updated_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+      ON CONFLICT DO NOTHING
+      RETURNING
+        registration_id,
+        stripe_checkout_session_id,
+        stripe_event_id,
+        stripe_payment_intent_id,
+        amount_total,
+        currency,
+        payment_status,
+        created_at,
+        updated_at
+    ),
+    existing AS (
+      SELECT
+        registration_id,
+        stripe_checkout_session_id,
+        stripe_event_id,
+        stripe_payment_intent_id,
+        amount_total,
+        currency,
+        payment_status,
+        created_at,
+        updated_at
+      FROM ${PAYMENTS_TABLE}
+      WHERE stripe_checkout_session_id = $2 OR stripe_event_id = $3
+      ORDER BY
+        CASE
+          WHEN stripe_checkout_session_id = $2 THEN 0
+          ELSE 1
+        END,
+        created_at ASC
+      LIMIT 1
+    )
+    SELECT
+      registration_id,
+      stripe_checkout_session_id,
+      stripe_event_id,
+      stripe_payment_intent_id,
+      amount_total,
+      currency,
+      payment_status,
+      created_at,
+      updated_at
+    FROM inserted
+    UNION ALL
+    SELECT
+      registration_id,
+      stripe_checkout_session_id,
+      stripe_event_id,
+      stripe_payment_intent_id,
+      amount_total,
+      currency,
+      payment_status,
+      created_at,
+      updated_at
+    FROM existing
+    LIMIT 1`,
+    [
+      input.registrationEmail,
+      input.stripeCheckoutSessionId,
+      input.stripeEventId,
+      input.stripePaymentIntentId,
+      input.amountTotal,
+      input.currency,
+      input.paymentStatus,
+    ],
+  );
+
+  if (!result.rows[0]) {
+    throw new Error("Unable to persist payment record.");
+  }
+
+  return mapPaymentRow(result.rows[0]);
+}
+
+function mapPaymentRow(row: PaymentRow): PaymentRecord {
+  return {
+    amountTotal: row.amount_total,
+    createdAt: row.created_at,
+    currency: row.currency,
+    paymentStatus: row.payment_status,
+    registrationEmail: row.registration_id,
+    stripeCheckoutSessionId: row.stripe_checkout_session_id,
+    stripeEventId: row.stripe_event_id,
+    stripePaymentIntentId: row.stripe_payment_intent_id,
+    updatedAt: row.updated_at,
+  };
+}

--- a/lib/registration-store.ts
+++ b/lib/registration-store.ts
@@ -16,6 +16,14 @@ export type RegistrationRecord = {
   organizationOrAffiliation: string | null;
 };
 
+type RegistrationRow = {
+  created_at: string;
+  email: string;
+  full_name: string;
+  normalized_email: string;
+  organization_or_affiliation: string | null;
+};
+
 function buildFullName(values: RegistrationFormValues) {
   return `${values.firstName} ${values.lastName}`.trim();
 }
@@ -88,13 +96,7 @@ export async function createRegistration(
 }
 
 export async function listRegistrations(): Promise<RegistrationRecord[]> {
-  const result = await getDb().query<{
-    created_at: string;
-    email: string;
-    full_name: string;
-    normalized_email: string;
-    organization_or_affiliation: string | null;
-  }>(
+  const result = await getDb().query<RegistrationRow>(
     `SELECT
       full_name,
       email,
@@ -105,11 +107,37 @@ export async function listRegistrations(): Promise<RegistrationRecord[]> {
      ORDER BY created_at DESC`,
   );
 
-  return result.rows.map((row) => ({
+  return result.rows.map(mapRegistrationRow);
+}
+
+export async function getRegistrationByNormalizedEmail(normalizedEmail: string) {
+  const normalizedRegistrationEmail = normalizedEmail.trim().toLowerCase();
+
+  if (!normalizedRegistrationEmail) {
+    return null;
+  }
+
+  const result = await getDb().query<RegistrationRow>(
+    `SELECT
+      full_name,
+      email,
+      normalized_email,
+      organization_or_affiliation,
+      created_at
+     FROM ${REGISTRATIONS_TABLE}
+     WHERE normalized_email = $1`,
+    [normalizedRegistrationEmail],
+  );
+
+  return result.rows[0] ? mapRegistrationRow(result.rows[0]) : null;
+}
+
+function mapRegistrationRow(row: RegistrationRow): RegistrationRecord {
+  return {
     createdAt: row.created_at,
     email: row.email,
     fullName: row.full_name,
     normalizedEmail: row.normalized_email,
     organizationOrAffiliation: row.organization_or_affiliation,
-  }));
+  };
 }


### PR DESCRIPTION
## Summary
Implement Stripe webhook verification and payment truth for summit checkout.

## Related Issue
Closes #38 

## Changes
- added Stripe webhook endpoint at `/api/webhooks/stripe`
- verified Stripe signatures using the raw request body
- handled `checkout.session.completed`
- added payment persistence linked to registrations
- switched checkout metadata to truthful email-based linkage
- renamed registration lookup helper to match normalized email behavior
- made payment persistence idempotent across both Stripe event ID and checkout session ID
- tightened confirmation copy so browser redirects do not imply payment proof
- added payment/environment docs

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] duplicate event replay handled safely
- [x] duplicate checkout session replay handled safely
- [x] confirmation page does not claim redirect-only payment truth

## Notes
Existing Stripe Checkout Sessions created with the old metadata key may need to be recreated to link through the updated webhook path.