### PR TITLE
Issue 4-5: Tighten confirmation and error states

### DIFF
--- a/app/confirmation/page.tsx
+++ b/app/confirmation/page.tsx
@@ -26,20 +26,20 @@ export default async function ConfirmationPage({
         </h1>
         <p className="confirmation-page__lede">
           {fromCheckout
-            ? "Your checkout flow has reached its confirmation destination. Payment verification is handled server-side via Stripe webhooks after checkout returns."
-            : "This page is the public confirmation destination for the summit flow. It supports the live checkout return while staying clear that this page itself is not the payment source of truth."}
+            ? "You have returned from Stripe Checkout. Payment verification is handled server-side through Stripe webhooks."
+            : "This page is the public return point for the summit flow. It does not use the browser redirect as proof of payment."}
         </p>
 
         <div className="confirmation-status">
           <p className="confirmation-status__title">
             {fromCheckout
-              ? "Checkout return structure is ready"
-              : "Controlled confirmation placeholder"}
+              ? "Checkout return received"
+              : "Return point ready"}
           </p>
           <p className="confirmation-status__body">
             {fromCheckout
-              ? "You are seeing the public page used after checkout returns. Verified Stripe webhook events, not this redirect, determine whether payment is recorded."
-              : "This route completes the public flow shape without claiming payment success from the browser alone."}
+              ? "Watch for summit follow-up details. If anything needs attention, we will use the registration information you provided."
+              : "Use this page as the controlled destination after checkout, without claiming payment success from the redirect alone."}
           </p>
         </div>
       </div>
@@ -48,22 +48,20 @@ export default async function ConfirmationPage({
         <section className="confirmation-section">
           <h2>What happens next</h2>
           <ol className="confirmation-list">
-            <li>Your registration and checkout path can end here cleanly.</li>
-            <li>Summit details and follow-up instructions can be added here later.</li>
-            <li>Payment records are created only after Stripe sends a verified webhook event.</li>
+            <li>Your checkout return has a stable place to land.</li>
+            <li>Payment records come from verified Stripe webhook events.</li>
+            <li>Summit follow-up can be added here without changing payment truth.</li>
           </ol>
         </section>
 
         <section className="confirmation-section">
           <h2>What this page means today</h2>
           <p>
-            This is a calm handoff point for the live checkout return. The page
-            gives the user a stable destination without overstating what the
-            browser alone can prove.
+            This is a calm handoff point after Stripe. It gives you a stable
+            next step without treating the browser redirect as payment proof.
           </p>
           <p className="confirmation-section__note">
-            Details, attendance instructions, or payment-specific messaging can
-            be layered in later without replacing the route.
+            Return to the summit page if you want to review the event details.
           </p>
         </section>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -531,6 +531,24 @@ a {
   padding-top: var(--space-6);
 }
 
+.register-success-error {
+  width: 100%;
+  max-width: 24rem;
+  padding-top: var(--space-4);
+  color: var(--color-accent);
+  line-height: 1.5;
+}
+
+.register-success-error p {
+  margin: 0;
+}
+
+.register-success-error__title {
+  margin-bottom: 0.25rem;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
 .register-success-actions {
   display: flex;
   flex-wrap: wrap;

--- a/app/register/success/checkout-button.tsx
+++ b/app/register/success/checkout-button.tsx
@@ -24,20 +24,17 @@ export function CheckoutButton({ email }: CheckoutButtonProps) {
       });
 
       const payload = (await response.json()) as {
-        error?: string;
         url?: string;
       };
 
       if (!response.ok || !payload.url) {
-        setErrorMessage(
-          payload.error ?? "We couldn't start checkout right now. Please try again.",
-        );
+        setErrorMessage("Checkout did not start. Try again when you are ready.");
         return;
       }
 
       window.location.assign(payload.url);
     } catch {
-      setErrorMessage("We couldn't start checkout right now. Please try again.");
+      setErrorMessage("Checkout did not start. Try again when you are ready.");
     } finally {
       setIsPending(false);
     }
@@ -54,9 +51,10 @@ export function CheckoutButton({ email }: CheckoutButtonProps) {
         {isPending ? "Redirecting to Payment..." : "Continue to Payment"}
       </button>
       {errorMessage ? (
-        <p className="register-success-section__note" role="alert">
-          {errorMessage}
-        </p>
+        <div className="register-success-error" role="alert">
+          <p className="register-success-error__title">Payment step paused</p>
+          <p>{errorMessage}</p>
+        </div>
       ) : null}
     </>
   );

--- a/app/register/success/page.tsx
+++ b/app/register/success/page.tsx
@@ -18,9 +18,8 @@ export default async function RegisterSuccessPage() {
           Your details are in place.
         </h1>
         <p className="register-success-page__lede">
-          {draft.firstName} {draft.lastName}, we have your registration details
-          and the next step is payment. This page is here to make the handoff
-          feel clear before checkout begins.
+          {draft.firstName} {draft.lastName}, your registration details are
+          saved. Continue to payment to hold your place in the summit flow.
         </p>
       </div>
 
@@ -29,8 +28,8 @@ export default async function RegisterSuccessPage() {
           <h2>What happens next</h2>
           <ol className="register-success-list">
             <li>Your registration details stay ready for checkout.</li>
-            <li>Payment is the next step in the summit flow.</li>
-            <li>Confirmation comes after checkout is complete.</li>
+            <li>Stripe Checkout is the next step.</li>
+            <li>After checkout, you will return to a confirmation point.</li>
           </ol>
         </section>
 
@@ -50,9 +49,8 @@ export default async function RegisterSuccessPage() {
         <div className="register-success-actions__content">
           <h2>Continue when you&apos;re ready</h2>
           <p>
-            Stripe is still operating through the current scaffold, so this
-            continues into the existing payment-ready path without implying
-            completed payment.
+            You will finish payment through Stripe. The return page gives you a
+            clear next step while payment is verified server-side.
           </p>
         </div>
         <div className="register-success-actions__links">


### PR DESCRIPTION
## Summary
Tighten the register success, checkout failure, and confirmation states so the flow is clearer and more action-oriented without implying payment success.

## Related Issue
Closes #36 

## Changes
- refined `/register/success` copy to frame it as a transition to payment
- refined `/confirmation` copy to keep it truthful as a checkout return point
- updated checkout failure messaging to be calm and retry-oriented
- made small supporting style updates for clarity

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] manually checked `/confirmation?mode=checkout`
- [x] manually checked `/register/success` with a valid draft cookie

## Notes
No backend, Stripe, webhook, schema, or payment-state logic changed.