### PR TITLE
Issue 5-6: add basic admin metrics for registrations and paid counts

### DIFF
--- a/app/admin/(protected)/page.tsx
+++ b/app/admin/(protected)/page.tsx
@@ -1,8 +1,14 @@
 import Link from "next/link";
 import { isCurrentAdminOwner } from "@/lib/admin-auth-server";
+import { countPaidPayments } from "@/lib/payment-store";
+import { countRegistrations } from "@/lib/registration-store";
 
 export default async function AdminPage() {
-  const isOwner = await isCurrentAdminOwner();
+  const [isOwner, totalRegistrations, totalPaid] = await Promise.all([
+    isCurrentAdminOwner(),
+    countRegistrations(),
+    countPaidPayments(),
+  ]);
 
   return (
     <section className="admin-page">
@@ -25,6 +31,14 @@ export default async function AdminPage() {
       </section>
 
       <section className="admin-summary">
+        <div className="admin-summary__item">
+          <p className="admin-summary__label">Total registrations</p>
+          <p className="admin-summary__value">{totalRegistrations}</p>
+        </div>
+        <div className="admin-summary__item">
+          <p className="admin-summary__label">Total paid</p>
+          <p className="admin-summary__value">{totalPaid}</p>
+        </div>
         <div className="admin-summary__item">
           <p className="admin-summary__label">Access</p>
           <p className="admin-summary__value">Protected</p>

--- a/lib/payment-store.ts
+++ b/lib/payment-store.ts
@@ -153,6 +153,16 @@ export async function createPaymentRecord(
   return mapPaymentRow(result.rows[0]);
 }
 
+export async function countPaidPayments() {
+  const result = await getDb().query<{ count: string }>(
+    `SELECT COUNT(*) AS count
+     FROM ${PAYMENTS_TABLE}
+     WHERE payment_status = 'paid'`,
+  );
+
+  return Number(result.rows[0]?.count ?? 0);
+}
+
 function mapPaymentRow(row: PaymentRow): PaymentRecord {
   return {
     amountTotal: row.amount_total,

--- a/lib/registration-store.ts
+++ b/lib/registration-store.ts
@@ -110,6 +110,14 @@ export async function listRegistrations(): Promise<RegistrationRecord[]> {
   return result.rows.map(mapRegistrationRow);
 }
 
+export async function countRegistrations() {
+  const result = await getDb().query<{ count: string }>(
+    `SELECT COUNT(*) AS count FROM ${REGISTRATIONS_TABLE}`,
+  );
+
+  return Number(result.rows[0]?.count ?? 0);
+}
+
 export async function getRegistrationByNormalizedEmail(normalizedEmail: string) {
   const normalizedRegistrationEmail = normalizedEmail.trim().toLowerCase();
 


### PR DESCRIPTION
## Summary
Add basic admin metrics to display total registrations and total paid on the protected admin dashboard.

## Related Issue
Closes #45 

## Changes
- added server-side counts for registrations and payments
- surfaced metrics on `/admin` dashboard
- ensured counts are derived from database truth only

## Verification checklist
- [x] admin can log in successfully
- [x] `/admin` loads without errors
- [x] total registrations displays correctly
- [x] total paid displays correctly
- [x] zero-state renders cleanly

## Notes
Read-only change. No impact to auth, Stripe, webhook handling, or data persistence.