### PR TITLE
Issue 6-3: build meeting-ready summit page

### DIFF
--- a/app/summit/page.tsx
+++ b/app/summit/page.tsx
@@ -4,62 +4,154 @@ export default function SummitPage() {
   return (
     <div className="public-page">
       <section className="public-section">
-        <h1 className="public-section__title">
-          Settled on the Field Summit
-        </h1>
+        <h1 className="public-section__title">The Success Summit</h1>
         <p className="public-section__body">
-          A focused event for people navigating transition and looking for a
-          clearer next move, grounded conversations, and practical direction.
+          A leadership and transition summit for athletes, veterans, and
+          professionals navigating what&apos;s next.
+        </p>
+        <div className="public-actions">
+          <Link className="public-button" href="/register">
+            Register Interest
+          </Link>
+          <Link className="public-link" href="/">
+            View Landing
+          </Link>
+        </div>
+      </section>
+
+      <section className="public-section public-section--bordered">
+        <p className="public-section__eyebrow">Event Overview</p>
+        <h2 className="public-section__heading">A structured summit with real-world relevance</h2>
+        <p className="public-section__body">
+          The Success Summit brings together people navigating leadership,
+          transition, and performance after major shifts in identity, career,
+          and direction.
+        </p>
+        <p className="public-section__body public-section__body--spaced">
+          It is built for athletes, veterans, university and athletic leaders,
+          and professionals who want practical perspective, stronger alignment,
+          and a credible room to connect in.
+        </p>
+      </section>
+
+      <section className="public-section public-section--bordered">
+        <p className="public-section__eyebrow">Three Themes</p>
+        <h2 className="public-section__heading">Focused on what drives forward motion</h2>
+        <div className="public-theme-grid">
+          <section className="public-theme-card">
+            <h3>Mental Success</h3>
+            <p>
+              Strengthen mindset, resilience, and identity under pressure and
+              change.
+            </p>
+          </section>
+          <section className="public-theme-card">
+            <h3>Transition Success</h3>
+            <p>
+              Clarify direction and align the next chapter with purpose,
+              strengths, and opportunity.
+            </p>
+          </section>
+          <section className="public-theme-card">
+            <h3>Actions for Success</h3>
+            <p>
+              Turn insight into practical next moves across leadership, career,
+              and life.
+            </p>
+          </section>
+        </div>
+      </section>
+
+      <section className="public-section public-section--bordered">
+        <p className="public-section__eyebrow">Program Structure</p>
+        <h2 className="public-section__heading">Three days, three focused tracks</h2>
+        <div className="public-theme-grid">
+          <section className="public-theme-card">
+            <h3>Day 1 — Mental + Identity</h3>
+            <ul className="public-section__list">
+              <li>Mindset, resilience, and personal leadership</li>
+              <li>Identity shifts after sport, service, or role change</li>
+            </ul>
+          </section>
+          <section className="public-theme-card">
+            <h3>Day 2 — Transition + Alignment</h3>
+            <ul className="public-section__list">
+              <li>Career direction, alignment, and next-step clarity</li>
+              <li>Leadership conversations across education, sport, and industry</li>
+            </ul>
+          </section>
+          <section className="public-theme-card">
+            <h3>Day 3 — Action + Execution</h3>
+            <ul className="public-section__list">
+              <li>Practical strategies for momentum after the summit</li>
+              <li>Execution planning, accountability, and connection</li>
+            </ul>
+          </section>
+        </div>
+      </section>
+
+      <section className="public-section public-section--bordered">
+        <p className="public-section__eyebrow">Outcomes</p>
+        <h2 className="public-section__heading">What the experience is built to deliver</h2>
+        <ul className="public-section__list">
+          <li>breakout sessions</li>
+          <li>networking</li>
+          <li>leadership development</li>
+          <li>career alignment</li>
+        </ul>
+      </section>
+
+      <section className="public-section public-section--bordered">
+        <p className="public-section__eyebrow">Logistics</p>
+        <h2 className="public-section__heading">Built for a credible live gathering</h2>
+        <p className="public-section__body">
+          Location: Indianapolis, IN
+        </p>
+        <p className="public-section__body public-section__body--spaced">
+          Venue: TBD
+        </p>
+        <p className="public-section__body public-section__body--spaced">
+          Final venue and schedule details will be released to registered
+          attendees.
+        </p>
+        <p className="public-section__body public-section__body--spaced">
+          The format is designed to support university, athletic, and
+          leadership partnership opportunities without overextending the event
+          promise.
+        </p>
+      </section>
+
+      <section className="public-section public-section--bordered">
+        <p className="public-section__eyebrow">For Partners & Sponsors</p>
+        <h2 className="public-section__heading">A focused environment for meaningful connection</h2>
+        <p className="public-section__body">
+          The summit creates direct access to an audience shaped by leadership,
+          performance, transition, and long-term growth.
+        </p>
+        <p className="public-section__body public-section__body--spaced">
+          It offers a leadership-focused environment where sponsors and
+          partners can connect with talent, build visibility, and participate
+          in a credible conversation about what comes next.
         </p>
         <Link className="public-button" href="/register">
-          Register Now
+          Get Involved
         </Link>
       </section>
 
       <section className="public-section public-section--bordered">
-        <h2 className="public-section__heading">
-          Who It&apos;s For
-        </h2>
-        <ul className="public-section__list">
-          <li>Athletes preparing for life beyond the current season</li>
-          <li>Veterans navigating a new civilian chapter</li>
-          <li>Transitioning professionals looking for renewed direction</li>
-        </ul>
-      </section>
-
-      <section className="public-section public-section--bordered">
-        <h2 className="public-section__heading">
-          What You&apos;ll Get
-        </h2>
-        <ul className="public-section__list">
-          <li>Direction</li>
-          <li>Clarity</li>
-          <li>Connection</li>
-          <li>Real conversations</li>
-        </ul>
-      </section>
-
-      <section className="public-section public-section--bordered">
-        <h2 className="public-section__heading">
-          Structure and Experience
-        </h2>
+        <h2 className="public-section__heading">Be part of the summit conversation</h2>
         <p className="public-section__body">
-          Expect focused talks, experienced speakers, room for interaction, and
-          space to build meaningful connections with people facing similar
-          questions about what comes next.
+          Register interest now and receive event updates as details are
+          finalized.
         </p>
-      </section>
-
-      <section className="public-section public-section--bordered">
-        <h2 className="public-section__heading">
-          Ready to Join?
-        </h2>
-        <p className="public-section__body">
-          Reserve your place and move into the next step with intention.
-        </p>
-        <Link className="public-link" href="/register">
-          Register Now
-        </Link>
+        <div className="public-actions">
+          <Link className="public-button" href="/register">
+            Register Interest
+          </Link>
+          <Link className="public-link" href="/">
+            View Landing
+          </Link>
+        </div>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
Built a meeting-ready summit page for The Success Summit.

## Related Issue
Closes #89 

## Changes
- Reframed `/summit` around The Success Summit
- Added event overview, themes, program structure, outcomes, and logistics
- Added partner/sponsor section with clear CTA
- Kept content flexible for venue and final schedule

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] Checked `/summit`
- [x] Verified Register Interest CTA
- [x] Checked dark mode

## Notes
No backend, payment, auth, or route behavior changed.