### PR TITLE
Issue 6-4: convert registration to interest-only flow

### DIFF
--- a/app/confirmation/page.tsx
+++ b/app/confirmation/page.tsx
@@ -1,45 +1,20 @@
 import Link from "next/link";
 
-function getSearchParamValue(value: string | string[] | undefined) {
-  return Array.isArray(value) ? value[0] : value;
-}
-
-type ConfirmationPageProps = {
-  searchParams: Promise<{
-    mode?: string | string[];
-  }>;
-};
-
-export default async function ConfirmationPage({
-  searchParams,
-}: ConfirmationPageProps) {
-  const resolvedSearchParams = await searchParams;
-  const mode = getSearchParamValue(resolvedSearchParams.mode);
-  const fromCheckout = mode === "checkout";
-
+export default function ConfirmationPage() {
   return (
     <section className="confirmation-page">
       <div className="confirmation-page__intro">
         <p className="confirmation-page__eyebrow">Confirmation</p>
-        <h1 className="confirmation-page__title">
-          Your next step is in place.
-        </h1>
+        <h1 className="confirmation-page__title">You&apos;re on the list.</h1>
         <p className="confirmation-page__lede">
-          {fromCheckout
-            ? "You have returned from Stripe Checkout. Payment verification is handled server-side through Stripe webhooks."
-            : "This page is the public return point for the summit flow. It does not use the browser redirect as proof of payment."}
+          We&apos;ve received your registration. We&apos;ll follow up with event
+          details, updates, and next steps.
         </p>
 
         <div className="confirmation-status">
-          <p className="confirmation-status__title">
-            {fromCheckout
-              ? "Checkout return received"
-              : "Return point ready"}
-          </p>
+          <p className="confirmation-status__title">Registration received</p>
           <p className="confirmation-status__body">
-            {fromCheckout
-              ? "Watch for summit follow-up details. If anything needs attention, we will use the registration information you provided."
-              : "Use this page as the controlled destination after checkout, without claiming payment success from the redirect alone."}
+            Early access and partner information will be shared soon.
           </p>
         </div>
       </div>
@@ -48,20 +23,22 @@ export default async function ConfirmationPage({
         <section className="confirmation-section">
           <h2>What happens next</h2>
           <ol className="confirmation-list">
-            <li>Your checkout return has a stable place to land.</li>
-            <li>Payment records come from verified Stripe webhook events.</li>
-            <li>Summit follow-up can be added here without changing payment truth.</li>
+            <li>Your registration is saved.</li>
+            <li>We&apos;ll send updates as plans are finalized.</li>
+            <li>You&apos;ll receive next steps from the summit team.</li>
           </ol>
         </section>
 
         <section className="confirmation-section">
-          <h2>What this page means today</h2>
+          <h2>What this means</h2>
           <p>
-            This is a calm handoff point after Stripe. It gives you a stable
-            next step without treating the browser redirect as payment proof.
+            You have a confirmed place in the interest list for The Success
+            Summit. Use this point as your calm next step while we prepare more
+            event details.
           </p>
           <p className="confirmation-section__note">
-            Return to the summit page if you want to review the event details.
+            Return to the summit page if you want to review the event details
+            again.
           </p>
         </section>
       </div>
@@ -69,15 +46,15 @@ export default async function ConfirmationPage({
       <section className="confirmation-actions">
         <h2>Keep moving</h2>
         <p>
-          If you want to review the event again or start over from the public
-          site, use either path below.
+          If you want to review the event again or update your registration,
+          use either path below.
         </p>
         <div className="confirmation-actions__links">
           <Link className="confirmation-actions__primary" href="/summit">
             Back to Summit
           </Link>
-          <Link className="confirmation-actions__secondary" href="/">
-            Return Home
+          <Link className="confirmation-actions__secondary" href="/register">
+            Update Registration
           </Link>
         </div>
       </section>

--- a/app/register/actions.ts
+++ b/app/register/actions.ts
@@ -59,5 +59,5 @@ export async function submitRegistration(
   const draft = buildRegistrationDraft(values);
   await writeRegistrationDraft(draft);
 
-  redirect("/register/success");
+  redirect("/confirmation");
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -9,8 +9,6 @@ function getSearchParamValue(value: string | string[] | undefined) {
 type RegisterPageProps = {
   searchParams: Promise<{
     error?: string | string[];
-    mode?: string | string[];
-    step?: string | string[];
   }>;
 };
 
@@ -19,65 +17,26 @@ export default async function RegisterPage({
 }: RegisterPageProps) {
   const resolvedSearchParams = await searchParams;
   const draft = await readRegistrationDraft();
-  const step = getSearchParamValue(resolvedSearchParams.step);
-  const mode = getSearchParamValue(resolvedSearchParams.mode);
   const error = getSearchParamValue(resolvedSearchParams.error);
-  const paymentReady = step === "payment" && draft !== null;
 
   return (
     <section className="register-page">
       <div className="register-page__intro">
         <p className="register-page__eyebrow">Registration</p>
         <h1 className="register-page__title">
-          Take your next step with intention.
+          Register your interest.
         </h1>
         <p className="register-page__lede">
-          Share a few details so we can hold your place and carry you into the
-          payment step with clarity. This is a focused summit for people
-          navigating transition and looking for practical direction.
+          Share a few details to reserve your spot. We&apos;ll follow up with
+          event details, updates, and next steps for the summit.
         </p>
 
         {error === "draft" ? (
           <div className="register-status register-status--error">
-            <p className="register-status__title">
-              Save your registration details before payment
-            </p>
+            <p className="register-status__title">Review your registration details</p>
             <p className="register-status__body">
-              A valid registration draft was not available for checkout. Review
-              your details and continue again.
-            </p>
-          </div>
-        ) : null}
-
-        {paymentReady ? (
-          <div className="register-status register-status--success">
-            <p className="register-status__title">Registration details saved</p>
-            <p className="register-status__body">
-              {draft?.firstName} {draft?.lastName} is ready for the payment
-              handoff with {draft?.email}.
-            </p>
-          </div>
-        ) : null}
-
-        {mode === "stub" ? (
-          <div className="register-status">
-            <p className="register-status__title">Checkout stub mode</p>
-            <p className="register-status__body">
-              Stripe checkout is not live in this environment yet. Your payment
-              handoff is wired and ready for keys to be added later.
-            </p>
-          </div>
-        ) : null}
-
-        {mode === "stripe-ready" ? (
-          <div className="register-status">
-            <p className="register-status__title">
-              Stripe configuration detected
-            </p>
-            <p className="register-status__body">
-              Checkout session scaffolding is in place. The final Stripe API
-              call can be added with minimal change once live integration work
-              begins.
+              We couldn&apos;t find a saved registration summary for that step.
+              Review your details and submit again.
             </p>
           </div>
         ) : null}
@@ -86,7 +45,6 @@ export default async function RegisterPage({
       <div className="register-page__grid">
         <RegisterForm
           defaultValues={draft ?? EMPTY_REGISTRATION_FORM_VALUES}
-          paymentReady={paymentReady}
         />
 
         <aside className="register-sidebar">
@@ -108,12 +66,12 @@ export default async function RegisterPage({
             <h2>What happens next</h2>
             <ol>
               <li>Complete your registration details.</li>
-              <li>Review the payment step.</li>
-              <li>Receive confirmation once checkout is live.</li>
+              <li>We save your interest and reserve your spot.</li>
+              <li>We follow up with details, updates, and next steps.</li>
             </ol>
             <p className="register-panel__note">
-              Questions or hesitation are normal. This step is here to make the
-              path feel clear before payment is introduced.
+              If you&apos;re still deciding, that&apos;s fine. This form keeps the
+              next step simple and gives us a clear way to follow up.
             </p>
           </section>
         </aside>

--- a/app/register/register-form.tsx
+++ b/app/register/register-form.tsx
@@ -14,7 +14,6 @@ const INITIAL_STATE: RegisterFormState = {
 
 type RegisterFormProps = {
   defaultValues: RegistrationFormValues;
-  paymentReady: boolean;
 };
 
 type RegisterFieldProps = {
@@ -93,7 +92,6 @@ function RegisterField({
 
 export function RegisterForm({
   defaultValues,
-  paymentReady,
 }: RegisterFormProps) {
   const [state, formAction, pending] = useActionState(
     submitRegistration,
@@ -189,27 +187,18 @@ export function RegisterForm({
 
       <div className="register-cta">
         <div className="register-cta__content">
-          <h2>
-            {paymentReady
-              ? "Your details are ready for payment"
-              : "Continue when you're ready"}
-          </h2>
+          <h2>Reserve your spot</h2>
           <p>
-            {paymentReady
-              ? "Your registration draft is saved. Continue to payment to use the new checkout entry point, or adjust the form first and continue when it looks right."
-              : "Payment is the next step. This page now captures your details, validates the essentials, and prepares a clean handoff before checkout is added."}
+            Register your interest now. We&apos;ll save your details and follow
+            up with event information, updates, and next steps.
           </p>
         </div>
         <button
           className="register-cta__button"
-          disabled={paymentReady ? false : pending}
-          formAction={paymentReady ? "/api/checkout" : undefined}
-          formMethod={paymentReady ? "post" : undefined}
+          disabled={pending}
           type="submit"
         >
-          {pending
-            ? "Saving your details..."
-            : "Continue to Payment"}
+          {pending ? "Saving your details..." : "Register Interest"}
         </button>
       </div>
     </form>

--- a/app/register/success/page.tsx
+++ b/app/register/success/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { readRegistrationDraft } from "../registration";
-import { CheckoutButton } from "./checkout-button";
 
 export default async function RegisterSuccessPage() {
   const draft = await readRegistrationDraft();
@@ -15,11 +14,12 @@ export default async function RegisterSuccessPage() {
       <div className="register-success-page__intro">
         <p className="register-success-page__eyebrow">Registration</p>
         <h1 className="register-success-page__title">
-          Your details are in place.
+          You&apos;re on the list.
         </h1>
         <p className="register-success-page__lede">
-          {draft.firstName} {draft.lastName}, your registration details are
-          saved. Continue to payment to hold your place in the summit flow.
+          {draft.firstName} {draft.lastName}, we&apos;ve received your
+          registration. We&apos;ll follow up with event details, updates, and
+          next steps.
         </p>
       </div>
 
@@ -27,9 +27,9 @@ export default async function RegisterSuccessPage() {
         <section className="register-success-section">
           <h2>What happens next</h2>
           <ol className="register-success-list">
-            <li>Your registration details stay ready for checkout.</li>
-            <li>Stripe Checkout is the next step.</li>
-            <li>After checkout, you will return to a confirmation point.</li>
+            <li>Your registration details are saved.</li>
+            <li>We&apos;ll share updates as event planning progresses.</li>
+            <li>You&apos;ll receive next steps directly from the summit team.</li>
           </ol>
         </section>
 
@@ -39,22 +39,24 @@ export default async function RegisterSuccessPage() {
           {draft.organization ? <p>{draft.organization}</p> : null}
           {draft.role ? <p>{draft.role}</p> : null}
           <p className="register-success-section__note">
-            Need to adjust something before payment? Return to registration and
-            update your details.
+            Need to adjust something? Return to registration and update your
+            details.
           </p>
         </section>
       </div>
 
       <section className="register-success-actions">
         <div className="register-success-actions__content">
-          <h2>Continue when you&apos;re ready</h2>
+          <h2>Keep moving</h2>
           <p>
-            You will finish payment through Stripe. The return page gives you a
-            clear next step while payment is verified server-side.
+            Review the summit details again or return to registration if you
+            want to change anything before we follow up.
           </p>
         </div>
         <div className="register-success-actions__links">
-          <CheckoutButton email={draft.email} />
+          <Link className="register-success-actions__primary" href="/confirmation">
+            View Confirmation
+          </Link>
           <Link className="register-success-actions__secondary" href="/register">
             Edit Registration
           </Link>


### PR DESCRIPTION
## Summary
Converted registration to an interest-only flow for meeting readiness.

## Related Issue
Closes #90 

## Changes
- Redirected successful registration directly to `/confirmation`
- Removed payment, checkout, Stripe, and webhook language from public registration flow
- Converted `/register/success` into a safe non-payment fallback page
- Kept registration persistence and duplicate protection unchanged

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] Submitted test registration
- [x] Confirmed redirect to `/confirmation`
- [x] Confirmed `/register/success` is safe
- [x] Confirmed no payment language appears in flow

## Notes
Stripe code remains in the repo but is no longer reachable from the public registration path.