### PR TITLE
Issue 6-5: add visual polish and footer structure

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,7 +17,9 @@
   --space-6: 1.5rem;
   --space-8: 2rem;
   --space-12: 3rem;
-  --content-width: 64rem;
+  --space-16: 4rem;
+  --content-width: 86rem;
+  --copy-width: 56rem;
 }
 
 [data-theme="dark"] {
@@ -79,6 +81,10 @@ a:hover {
   margin: 0 auto;
   padding-left: var(--space-6);
   padding-right: var(--space-6);
+}
+
+.page-wrapper--hero {
+  width: 100%;
 }
 
 .shell-header,
@@ -160,16 +166,94 @@ a:hover {
 
 .shell-footer {
   border-top: 1px solid var(--color-border);
+  color: var(--color-muted);
+}
+
+.shell-footer__inner {
+  padding-top: var(--space-6);
+  padding-bottom: var(--space-6);
+}
+
+.shell-footer__brand,
+.shell-footer__meta {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.shell-footer__title {
+  margin: 0;
+  color: var(--color-primary);
+  font-size: 1.25rem;
+}
+
+.shell-footer__tagline,
+.shell-footer__contact,
+.shell-footer__copyright {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.shell-footer__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+
+.shell-footer__nav-title {
+  margin: 0 0 0.75rem;
+  color: var(--color-primary);
+  font-size: 0.95rem;
+}
+
+.shell-footer__links {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.shell-footer__powered-by {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.shell-footer__powered-label {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.shell-footer__powered-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.shell-footer__logo-placeholder {
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
 }
 
 .public-page {
+  width: 100%;
   display: grid;
   gap: var(--space-8);
 }
 
 .public-section {
+  width: 100%;
   padding-top: var(--space-8);
   padding-bottom: var(--space-8);
+}
+
+.public-section--hero {
+  padding-top: var(--space-12);
 }
 
 .public-section--bordered {
@@ -202,10 +286,14 @@ a:hover {
 
 .public-section__body,
 .public-section__list {
-  max-width: 42rem;
+  max-width: var(--copy-width);
   margin: 0;
   color: var(--color-muted);
   line-height: 1.6;
+}
+
+.public-section__copy {
+  max-width: 64rem;
 }
 
 .public-section__list {
@@ -223,11 +311,73 @@ a:hover {
   margin-top: var(--space-6);
 }
 
+.public-section__body--wide {
+  max-width: none;
+  width: 100%;
+}
+
 .public-actions {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-4);
   margin-top: var(--space-6);
+}
+
+.public-hero {
+  display: grid;
+  gap: var(--space-8);
+  align-items: center;
+}
+
+.public-hero__content {
+  max-width: var(--copy-width);
+}
+
+.public-hero__media,
+.public-image-band {
+  width: 100%;
+}
+
+.public-image-frame {
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.public-image-frame img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.public-image-frame--hero {
+  box-shadow: 0 24px 48px rgba(17, 24, 39, 0.12);
+}
+
+.public-image-frame--band {
+  margin-top: var(--space-6);
+}
+
+.audience-grid {
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.audience-grid--full {
+  max-width: none;
+  width: 100%;
+}
+
+.audience-card {
+  padding: 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-weight: 500;
 }
 
 .public-button,
@@ -257,6 +407,46 @@ a:hover {
 .public-link:hover {
   border-color: var(--color-secondary);
   color: var(--color-secondary);
+}
+
+@media (min-width: 900px) {
+  .public-hero {
+    grid-template-columns: minmax(0, 1.05fr) minmax(20rem, 0.95fr);
+    gap: var(--space-12);
+  }
+}
+
+@media (max-width: 720px) {
+  .page-wrapper {
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
+  }
+
+  .shell-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .shell-header__actions {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .nav-list {
+    flex-wrap: wrap;
+  }
+
+  .public-section__title {
+    font-size: 2.25rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .shell-footer__grid {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
 }
 
 .public-theme-grid {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,40 +1,58 @@
 import Link from "next/link";
+import Image from "next/image";
 
 export default function HomePage() {
   return (
     <div className="public-page">
-      <section className="public-section">
-        <h1 className="public-section__title">
-          Find Your Direction. Keep Dominating.
-        </h1>
-        <p className="public-section__body">
-          The Success Summit brings athletes, veterans, and leaders together to
-          navigate transition and build what&apos;s next.
-        </p>
-        <div className="public-actions">
-          <Link className="public-button" href="/summit">
-            View Summit
-          </Link>
-          <Link className="public-link" href="/register">
-            Register Interest
-          </Link>
+      <section className="public-section public-section--hero">
+        <div className="public-hero page-wrapper--hero">
+          <div className="public-hero__content">
+            <h1 className="public-section__title">
+              Find Your Direction. Keep Dominating.
+            </h1>
+            <p className="public-section__body">
+              The Success Summit brings athletes, veterans, and leaders
+              together to navigate transition and build what&apos;s next.
+            </p>
+            <div className="public-actions">
+              <Link className="public-button" href="/summit">
+                View Summit
+              </Link>
+              <Link className="public-link" href="/register">
+                Register Interest
+              </Link>
+            </div>
+          </div>
+
+          <div className="public-hero__media">
+            <div className="public-image-frame public-image-frame--hero">
+              <Image
+                alt="Summit visual showing a structured event presentation with three focus areas."
+                height="1000"
+                src="/success-summit-hero.svg"
+                width="1600"
+              />
+            </div>
+          </div>
         </div>
       </section>
 
       <section className="public-section public-section--bordered">
         <p className="public-section__eyebrow">Who It&apos;s For</p>
         <h2 className="public-section__heading">Built for people in transition</h2>
-        <p className="public-section__body">
-          The summit is designed for people carrying responsibility, momentum,
-          and a real next decision.
-        </p>
-        <ul className="public-section__list">
-          <li>Student Veterans</li>
-          <li>Veterans</li>
-          <li>Student-Athletes</li>
-          <li>Athletic Leaders</li>
-          <li>Corporate Professionals</li>
-        </ul>
+        <div className="public-section__copy">
+          <p className="public-section__body">
+            The summit is designed for people carrying responsibility,
+            momentum, and a real next decision.
+          </p>
+        </div>
+        <div className="audience-grid audience-grid--full">
+          <div className="audience-card">Student Veterans</div>
+          <div className="audience-card">Veterans</div>
+          <div className="audience-card">Student-Athletes</div>
+          <div className="audience-card">Athletic Leaders</div>
+          <div className="audience-card">Corporate Professionals</div>
+        </div>
       </section>
 
       <section className="public-section public-section--bordered">
@@ -79,12 +97,12 @@ export default function HomePage() {
       <section className="public-section public-section--bordered">
         <p className="public-section__eyebrow">Why It Matters</p>
         <h2 className="public-section__heading">Direction changes outcomes</h2>
-        <p className="public-section__body">
+        <p className="public-section__body public-section__body--wide">
           Transition is hard when identity, structure, and expectations are all
           shifting at once. People do not just need encouragement. They need
           perspective, strategy, and a clearer path forward.
         </p>
-        <p className="public-section__body public-section__body--spaced">
+        <p className="public-section__body public-section__body--spaced public-section__body--wide">
           The Success Summit exists to fill that gap with grounded
           conversations, leadership insight, and a room built for what comes
           next.

--- a/app/summit/page.tsx
+++ b/app/summit/page.tsx
@@ -1,21 +1,37 @@
 import Link from "next/link";
+import Image from "next/image";
 
 export default function SummitPage() {
   return (
     <div className="public-page">
-      <section className="public-section">
-        <h1 className="public-section__title">The Success Summit</h1>
-        <p className="public-section__body">
-          A leadership and transition summit for athletes, veterans, and
-          professionals navigating what&apos;s next.
-        </p>
-        <div className="public-actions">
-          <Link className="public-button" href="/register">
-            Register Interest
-          </Link>
-          <Link className="public-link" href="/">
-            View Landing
-          </Link>
+      <section className="public-section public-section--hero">
+        <div className="public-hero page-wrapper--hero">
+          <div className="public-hero__content">
+            <h1 className="public-section__title">The Success Summit</h1>
+            <p className="public-section__body">
+              A leadership and transition summit for athletes, veterans, and
+              professionals navigating what&apos;s next.
+            </p>
+            <div className="public-actions">
+              <Link className="public-button" href="/register">
+                Register Interest
+              </Link>
+              <Link className="public-link" href="/">
+                View Landing
+              </Link>
+            </div>
+          </div>
+
+          <div className="public-hero__media">
+            <div className="public-image-frame public-image-frame--hero">
+              <Image
+                alt="Summit overview visual with a three-day structure and partner-ready event framing."
+                height="800"
+                src="/success-summit-overview.svg"
+                width="1600"
+              />
+            </div>
+          </div>
         </div>
       </section>
 

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,7 +1,43 @@
+import Link from "next/link";
+
 export function Footer() {
   return (
-    <div className="shell-footer page-wrapper">
-      © Settled on the Field
+    <div className="shell-footer">
+      <div className="page-wrapper shell-footer__inner">
+        <div className="shell-footer__grid">
+          <div className="shell-footer__brand">
+            <h2 className="shell-footer__title">The Success Summit</h2>
+            <p className="shell-footer__tagline">
+              Find Your Direction. Keep Dominating.
+            </p>
+          </div>
+
+          <nav aria-label="Footer">
+            <p className="shell-footer__nav-title">Explore</p>
+            <ul className="shell-footer__links">
+              <li>
+                <Link href="/summit">Summit</Link>
+              </li>
+              <li>
+                <Link href="/register">Register</Link>
+              </li>
+            </ul>
+          </nav>
+
+          <div className="shell-footer__meta">
+            <p className="shell-footer__contact">More details coming soon</p>
+            <p className="shell-footer__copyright">© Settled on the Field</p>
+          </div>
+
+          <div className="shell-footer__powered-by">
+            <p className="shell-footer__powered-label">Powered by</p>
+            <div className="shell-footer__powered-brand">
+              <div className="shell-footer__logo-placeholder" />
+              <span>CurlTech</span>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/public/success-summit-hero.svg
+++ b/public/success-summit-hero.svg
@@ -1,0 +1,27 @@
+<svg width="1600" height="1000" viewBox="0 0 1600 1000" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="1000" fill="#1E2A38"/>
+  <rect x="72" y="72" width="1456" height="856" rx="28" fill="#223142"/>
+  <rect x="120" y="118" width="1360" height="764" rx="22" fill="#F7F6F3"/>
+  <rect x="120" y="118" width="1360" height="248" rx="22" fill="#1E2A38"/>
+  <circle cx="1328" cy="244" r="124" fill="#D69E2E" fill-opacity="0.28"/>
+  <circle cx="1186" cy="184" r="72" fill="#C05621" fill-opacity="0.58"/>
+  <rect x="188" y="198" width="370" height="18" rx="9" fill="#D69E2E"/>
+  <rect x="188" y="242" width="596" height="58" rx="12" fill="#F7F6F3"/>
+  <rect x="188" y="326" width="438" height="18" rx="9" fill="#AFC0D1"/>
+  <rect x="188" y="434" width="402" height="298" rx="20" fill="#EFE8DB"/>
+  <rect x="622" y="434" width="402" height="298" rx="20" fill="#F2EEE6"/>
+  <rect x="1056" y="434" width="236" height="298" rx="20" fill="#1E2A38"/>
+  <rect x="1088" y="474" width="136" height="14" rx="7" fill="#D69E2E"/>
+  <rect x="1088" y="518" width="164" height="16" rx="8" fill="#F7F6F3"/>
+  <rect x="1088" y="560" width="136" height="16" rx="8" fill="#F7F6F3"/>
+  <rect x="1088" y="620" width="172" height="10" rx="5" fill="#AFC0D1"/>
+  <rect x="1088" y="650" width="148" height="10" rx="5" fill="#AFC0D1"/>
+  <rect x="1088" y="680" width="124" height="10" rx="5" fill="#AFC0D1"/>
+  <rect x="188" y="780" width="1104" height="44" rx="22" fill="#1E2A38"/>
+  <rect x="216" y="797" width="236" height="10" rx="5" fill="#D69E2E"/>
+  <rect x="1216" y="790" width="44" height="24" rx="12" fill="#C05621"/>
+  <rect x="264" y="488" width="246" height="150" rx="18" fill="#1E2A38"/>
+  <rect x="696" y="488" width="246" height="150" rx="18" fill="#C05621"/>
+  <rect x="304" y="658" width="168" height="12" rx="6" fill="#6B7280"/>
+  <rect x="736" y="658" width="168" height="12" rx="6" fill="#6B7280"/>
+</svg>

--- a/public/success-summit-overview.svg
+++ b/public/success-summit-overview.svg
@@ -1,0 +1,25 @@
+<svg width="1600" height="800" viewBox="0 0 1600 800" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1600" height="800" fill="#F7F6F3"/>
+  <rect x="80" y="80" width="1440" height="640" rx="28" fill="#1E2A38"/>
+  <rect x="124" y="126" width="520" height="548" rx="20" fill="#223142"/>
+  <rect x="694" y="126" width="250" height="548" rx="20" fill="#C05621"/>
+  <rect x="980" y="126" width="494" height="548" rx="20" fill="#F7F6F3"/>
+  <rect x="170" y="190" width="164" height="16" rx="8" fill="#D69E2E"/>
+  <rect x="170" y="238" width="334" height="34" rx="12" fill="#F7F6F3"/>
+  <rect x="170" y="294" width="280" height="14" rx="7" fill="#AFC0D1"/>
+  <rect x="170" y="386" width="424" height="1" fill="#445569"/>
+  <rect x="170" y="450" width="424" height="1" fill="#445569"/>
+  <rect x="170" y="514" width="424" height="1" fill="#445569"/>
+  <rect x="170" y="578" width="424" height="1" fill="#445569"/>
+  <circle cx="819" cy="254" r="74" fill="#F7F6F3" fill-opacity="0.2"/>
+  <circle cx="819" cy="400" r="74" fill="#F7F6F3" fill-opacity="0.2"/>
+  <circle cx="819" cy="546" r="74" fill="#F7F6F3" fill-opacity="0.2"/>
+  <rect x="1070" y="196" width="140" height="18" rx="9" fill="#D69E2E"/>
+  <rect x="1070" y="246" width="258" height="40" rx="12" fill="#1E2A38"/>
+  <rect x="1070" y="332" width="322" height="14" rx="7" fill="#6B7280"/>
+  <rect x="1070" y="368" width="290" height="14" rx="7" fill="#6B7280"/>
+  <rect x="1070" y="438" width="340" height="110" rx="18" fill="#EFE8DB"/>
+  <rect x="1100" y="470" width="120" height="10" rx="5" fill="#C05621"/>
+  <rect x="1100" y="500" width="208" height="10" rx="5" fill="#6B7280"/>
+  <rect x="1100" y="530" width="180" height="10" rx="5" fill="#6B7280"/>
+</svg>


### PR DESCRIPTION
## Summary
Added visual polish and cleaned up the public footer for meeting readiness.

## Related Issue
Closes #95 

## Changes
- Added local summit visuals for landing and summit pages
- Widened public layout behavior for a stronger desktop presentation
- Improved audience and section width handling
- Fixed the “Why It Matters” section width
- Rebuilt footer into a responsive 3-column layout
- Added a Powered by CurlTech block with logo placeholder
- Preserved dark mode and existing design tokens

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] Checked `/`
- [x] Checked `/summit`
- [x] Checked `/register`
- [x] Checked `/confirmation`
- [x] Checked footer alignment
- [x] Checked dark mode

## Notes
Presentation-only changes. No backend, payment, registration, or auth behavior changed.