### PR TITLE
Issue 6-12: introduce typography system and normalize font ownership

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -43,6 +43,10 @@
   box-sizing: border-box;
 }
 
+/* ==========================================================================
+   Typography
+   ========================================================================== */
+
 html {
   background: var(--color-background);
   color-scheme: light;
@@ -57,8 +61,26 @@ body {
   min-height: 100vh;
   background: var(--color-background);
   color: var(--color-text);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-body), system-ui, sans-serif;
   line-height: 1.5;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.hero-title {
+  font-family: var(--font-display), Georgia, serif;
+  letter-spacing: -0.03em;
 }
 
 body > header,
@@ -131,7 +153,6 @@ a:hover {
   padding: 0.625rem 1rem;
   background: var(--color-button-secondary-bg);
   color: var(--color-button-secondary-text);
-  font: inherit;
   font-weight: 600;
   line-height: 1.2;
   cursor: pointer;
@@ -705,7 +726,6 @@ a:hover {
   padding: 0.9375rem 1rem;
   background: var(--color-surface);
   color: var(--color-text);
-  font: inherit;
   font-size: 1rem;
   line-height: 1.5;
   font-weight: 400;
@@ -780,7 +800,6 @@ a:hover {
   padding: var(--space-4) var(--space-6);
   background: var(--color-button-primary-bg);
   color: var(--color-button-primary-text);
-  font: inherit;
   font-weight: 600;
   line-height: 1.2;
   cursor: pointer;
@@ -1056,7 +1075,6 @@ a:hover {
   border: 0;
   min-height: 3.5rem;
   padding: var(--space-4) var(--space-6);
-  font: inherit;
   font-weight: 600;
   line-height: 1.2;
 }
@@ -1149,7 +1167,6 @@ a:hover {
   padding: 0.9375rem 1rem;
   background: var(--color-surface);
   color: var(--color-text);
-  font: inherit;
   font-size: 1rem;
   line-height: 1.5;
 }
@@ -1170,7 +1187,6 @@ a:hover {
   padding: var(--space-4) var(--space-6);
   background: var(--color-button-primary-bg);
   color: var(--color-button-primary-text);
-  font: inherit;
   font-weight: 600;
   line-height: 1.2;
   cursor: pointer;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,26 @@
 import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/next";
+import { Playfair_Display, Inter } from 'next/font/google';
 import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
 import "./globals.css";
+
 
 export const metadata: Metadata = {
   title: "Settled on the Field",
   description: "Settled on the Field platform",
 };
+
+const playfair = Playfair_Display({
+  subsets: ['latin'],
+  weight: ['400', '600', '700'],
+  variable: '--font-display',
+});
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-body',
+});
 
 export default function RootLayout({
   children,
@@ -16,7 +29,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>
+      <body className={`${playfair.variable} ${inter.variable}`}>
         <header>
           <Header />
         </header>


### PR DESCRIPTION
## Summary
Introduces a consistent typography system using Playfair Display for headings and Inter for body text, and normalizes font ownership across globals.css.

## Related Issue
Closes #104 

## Changes
- Added Playfair Display and Inter via next/font in layout.tsx
- Applied font variables to root layout
- Established global typography rules in globals.css
- Ensured form controls and UI elements inherit body font
- Consolidated heading styles under display font

## Verification
- [x] Landing page uses Inter for body and Playfair for headings
- [x] Summit page typography consistent
- [x] Register and confirmation pages render correctly
- [x] Admin login unaffected
- [x] No layout or spacing regressions observed

## Notes
CSS-only change; no impact to logic, routes, or data handling.