### PR TITLE
Issue 6-14: add trust and proof layer to landing and summit pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,6 +41,34 @@ export default function HomePage() {
       </section>
 
       <section className="public-section public-section--bordered">
+        <p className="public-section__eyebrow">Why This Room Matters</p>
+        <h2 className="public-section__heading">Built for real transition, not generic advice</h2>
+        <div className="audience-grid audience-grid--full">
+          <section className="audience-card">
+            <h3>Who it is for</h3>
+            <p>
+              Athletes, veterans, and professionals carrying pressure, momentum,
+              and a real next decision.
+            </p>
+          </section>
+          <section className="audience-card">
+            <h3>What they get</h3>
+            <p>
+              Clear perspective, practical direction, and a room shaped around
+              execution instead of noise.
+            </p>
+          </section>
+          <section className="audience-card">
+            <h3>Why it is credible</h3>
+            <p>
+              The summit is structured around leadership, transition, and
+              real-world application, not abstract motivation.
+            </p>
+          </section>
+        </div>
+      </section>
+
+      <section className="public-section public-section--bordered">
         <p className="public-section__eyebrow">Who It&apos;s For</p>
         <h2 className="public-section__heading">Built for people in transition</h2>
         <div className="public-section__copy">
@@ -62,10 +90,9 @@ export default function HomePage() {
         <p className="public-section__eyebrow">What You&apos;ll Gain</p>
         <h2 className="public-section__heading">Practical value, not noise</h2>
         <ul className="public-section__list">
-          <li>clarity in transition</li>
-          <li>leadership perspective</li>
-          <li>real-world strategies</li>
-          <li>meaningful connections</li>
+          <li>leave with clearer direction</li>
+          <li>turn pressure into practical next steps</li>
+          <li>build stronger alignment for what comes next</li>
         </ul>
       </section>
 

--- a/app/summit/page.tsx
+++ b/app/summit/page.tsx
@@ -36,6 +36,34 @@ export default function SummitPage() {
       </section>
 
       <section className="public-section public-section--bordered">
+        <p className="public-section__eyebrow">Speaker Perspective</p>
+        <h2 className="public-section__heading">Credibility comes from the room</h2>
+        <div className="public-theme-grid">
+          <section className="public-theme-card">
+            <h3>Leadership practitioners</h3>
+            <p>
+              Sessions are built to reflect real leadership pressure, decision-making,
+              and transition work.
+            </p>
+          </section>
+          <section className="public-theme-card">
+            <h3>Athlete and veteran context</h3>
+            <p>
+              The summit is shaped for people moving out of structured environments
+              and into what comes next.
+            </p>
+          </section>
+          <section className="public-theme-card">
+            <h3>Applied conversation</h3>
+            <p>
+              The emphasis is on perspective people can use, not inflated bios or
+              generic inspiration.
+            </p>
+          </section>
+        </div>
+      </section>
+
+      <section className="public-section public-section--bordered">
         <p className="public-section__eyebrow">Event Overview</p>
         <h2 className="public-section__heading">A structured summit with real-world relevance</h2>
         <p className="public-section__body">
@@ -110,10 +138,9 @@ export default function SummitPage() {
         <p className="public-section__eyebrow">Outcomes</p>
         <h2 className="public-section__heading">What the experience is built to deliver</h2>
         <ul className="public-section__list">
-          <li>breakout sessions</li>
-          <li>networking</li>
-          <li>leadership development</li>
-          <li>career alignment</li>
+          <li>clarify the next move</li>
+          <li>strengthen leadership under change</li>
+          <li>leave with practical actions to execute</li>
         </ul>
       </section>
 


### PR DESCRIPTION
## Summary
Added a lightweight trust and proof layer to improve credibility and conversion clarity.

## Related Issue
Closes #109 

## Changes
- Added trust/proof section below landing hero (who it’s for, what they get, why it matters)
- Tightened outcome statements into short, action-oriented points
- Added lightweight speaker credibility section to summit page
- Reused existing card styles and kept implementation content-focused

## Verification
- [ ] Landing (light mode) — trust reads clearly under hero
- [ ] Landing (dark mode) — sections remain readable and not repetitive
- [ ] Summit (light mode) — credibility is clear at a glance
- [ ] Summit (dark mode) — content remains clean and structured

## Notes
Content-only update. No layout, typography, or backend changes.