### PR TITLE
Issue 6-15: tighten landing flow and reinforce CTA after trust

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -271,7 +271,7 @@ a:hover {
 .public-page {
   width: 100%;
   display: grid;
-  gap: var(--space-8);
+  gap: 0;
 }
 
 .public-section {
@@ -300,6 +300,10 @@ a:hover {
 .public-section--bordered {
   padding-top: var(--space-12);
   border-top: 1px solid var(--color-border);
+}
+
+.public-section--trust {
+  padding-bottom: var(--space-8);
 }
 
 .public-section__title {
@@ -369,6 +373,10 @@ a:hover {
   flex-wrap: wrap;
   gap: var(--space-4);
   margin-top: var(--space-6);
+}
+
+.public-actions--trust {
+  margin-top: var(--space-4);
 }
 
 .public-hero {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,7 +40,7 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="public-section public-section--bordered">
+      <section className="public-section public-section--bordered public-section--trust">
         <p className="public-section__eyebrow">Why This Room Matters</p>
         <h2 className="public-section__heading">Built for real transition, not generic advice</h2>
         <div className="audience-grid audience-grid--full">
@@ -66,17 +66,19 @@ export default function HomePage() {
             </p>
           </section>
         </div>
+        <div className="public-actions public-actions--trust">
+          <Link className="public-button" href="/summit">
+            View Summit
+          </Link>
+          <Link className="public-link" href="/register">
+            Register Interest
+          </Link>
+        </div>
       </section>
 
       <section className="public-section public-section--bordered">
         <p className="public-section__eyebrow">Who It&apos;s For</p>
-        <h2 className="public-section__heading">Built for people in transition</h2>
-        <div className="public-section__copy">
-          <p className="public-section__body">
-            The summit is designed for people carrying responsibility,
-            momentum, and a real next decision.
-          </p>
-        </div>
+        <h2 className="public-section__heading">A focused room for people navigating what&apos;s next</h2>
         <div className="audience-grid audience-grid--full">
           <div className="audience-card">Student Veterans</div>
           <div className="audience-card">Veterans</div>
@@ -84,16 +86,6 @@ export default function HomePage() {
           <div className="audience-card">Athletic Leaders</div>
           <div className="audience-card">Corporate Professionals</div>
         </div>
-      </section>
-
-      <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">What You&apos;ll Gain</p>
-        <h2 className="public-section__heading">Practical value, not noise</h2>
-        <ul className="public-section__list">
-          <li>leave with clearer direction</li>
-          <li>turn pressure into practical next steps</li>
-          <li>build stronger alignment for what comes next</li>
-        </ul>
       </section>
 
       <section className="public-section public-section--bordered">
@@ -125,24 +117,19 @@ export default function HomePage() {
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Why It Matters</p>
-        <h2 className="public-section__heading">Direction changes outcomes</h2>
-        <p className="public-section__body public-section__body--wide">
-          Transition is hard when identity, structure, and expectations are all
-          shifting at once. People do not just need encouragement. They need
-          perspective, strategy, and a clearer path forward.
-        </p>
-        <p className="public-section__body public-section__body--spaced public-section__body--wide">
-          The Success Summit exists to fill that gap with grounded
-          conversations, leadership insight, and a room built for what comes
-          next.
-        </p>
+        <p className="public-section__eyebrow">What You&apos;ll Gain</p>
+        <h2 className="public-section__heading">Practical value you can act on</h2>
+        <ul className="public-section__list">
+          <li>leave with clearer direction</li>
+          <li>turn pressure into practical next steps</li>
+          <li>build stronger alignment for what comes next</li>
+        </ul>
       </section>
 
       <section className="public-section public-section--bordered">
-        <h2 className="public-section__heading">Move toward what&apos;s next</h2>
+        <h2 className="public-section__heading">Take the next step with intention</h2>
         <p className="public-section__body">
-          Explore the summit or register interest now.
+          Review the summit details, then register your interest.
         </p>
         <div className="public-actions">
           <Link className="public-button" href="/summit">


### PR DESCRIPTION
## Summary
Tightened landing page flow and reinforced CTA placement to improve conversion clarity.

## Related Issue
Closes #111 

## Changes
- reordered sections to enforce Hero → CTA → Trust → Expansion → CTA flow
- removed duplicate messaging (“Why It Matters” and repeated audience framing)
- added CTA reinforcement inside trust section (no new section)
- scoped spacing to group trust + CTA while preserving section separation

## Verification checklist
- [ ] hero CTA appears immediately
- [ ] trust section followed by reinforcement CTA
- [ ] no duplicated messaging across sections
- [ ] sections feel distinct and readable (desktop + mobile)
- [ ] flow reads: direction → trust → understand → act

## Notes
Presentation-only changes; no component redesign or backend impact.