### PR TITLE
Issue 6-7: add persistent public header navigation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -132,7 +132,21 @@ a:hover {
   font-weight: 600;
 }
 
+.shell-header__brand {
+  min-width: 0;
+}
+
 .shell-header__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.shell-header__nav {
+  min-width: 0;
+}
+
+.shell-header__utility {
   display: flex;
   align-items: center;
   gap: var(--space-4);
@@ -149,6 +163,10 @@ a:hover {
 .nav-list a {
   color: var(--color-muted);
   font-weight: 600;
+}
+
+.shell-header__cta {
+  white-space: nowrap;
 }
 
 .theme-toggle {
@@ -582,23 +600,66 @@ a:hover {
     padding-right: var(--space-4);
   }
 
+  .public-section__title {
+    font-size: 2.25rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .public-hero-poster {
+    min-height: 30rem;
+  }
+
+  .public-hero-poster__overlay {
+    min-height: 30rem;
+    padding: var(--space-8);
+  }
+
+  .public-hero-poster__content {
+    max-width: 100%;
+  }
+
+  .public-hero-poster .public-section__title {
+    font-size: 2.15rem;
+    line-height: 1.02;
+  }
+
   .shell-header {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
+    gap: var(--space-6);
+  }
+
+  .shell-header__brand {
+    display: flex;
+    justify-content: center;
   }
 
   .shell-header__actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-4);
+  }
+
+  .shell-header__nav {
     width: 100%;
-    justify-content: space-between;
-    flex-wrap: wrap;
   }
 
   .nav-list {
-    flex-wrap: wrap;
+    width: 100%;
+    justify-content: center;
+    gap: var(--space-4);
   }
 
-  .public-section__title {
-    font-size: 2.25rem;
+  .shell-header__utility {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .shell-header__cta {
+    min-height: 3rem;
+    padding: 0.75rem 1.25rem;
+    font-size: 0.95rem;
   }
 }
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -4,23 +4,31 @@ import { ThemeToggle } from "@/components/theme-toggle";
 export function Header() {
   return (
     <div className="shell-header page-wrapper">
-      <div>
+      <div className="shell-header__brand">
         <Link className="brand-link" href="/">
           Settled on the Field
         </Link>
       </div>
       <div className="shell-header__actions">
-        <nav aria-label="Primary">
+        <nav aria-label="Primary" className="shell-header__nav">
           <ul className="nav-list">
             <li>
-              <Link href="/">Landing</Link>
+              <Link href="/">Home</Link>
             </li>
             <li>
               <Link href="/summit">Summit</Link>
             </li>
+            <li>
+              <Link href="/register">Register</Link>
+            </li>
           </ul>
         </nav>
-        <ThemeToggle />
+        <div className="shell-header__utility">
+          <Link className="public-button shell-header__cta" href="/register">
+            Register Now
+          </Link>
+          <ThemeToggle />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Added persistent public header navigation and fixed mobile layout issues.

## Related Issue
Closes #98 

## Changes
- added Home, Summit, Register, and Register Now to the public header
- structured mobile header into brand, nav, and action rows
- preserved desktop header layout
- added mobile-only hero containment fixes so headline text stays inside the card

## Verification checklist
- [ ] header appears on public pages
- [ ] Home, Summit, Register, and Register Now route correctly
- [ ] mobile header layout is readable
- [ ] hero headline no longer overflows on common phone widths
- [ ] desktop layout remains strong
- [ ] landing flow still reads Hero → CTA → Trust → Supporting detail → CTA

## Notes
Presentation/layout-only changes. No payment, admin, or backend changes.