### PR TITLE
Issue 6-17: refine theme toggle to subtle icon control

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -170,19 +170,38 @@ a:hover {
 }
 
 .theme-toggle {
-  border: 1px solid var(--color-button-secondary-border);
-  min-height: 2.75rem;
-  padding: 0.625rem 1rem;
-  background: var(--color-button-secondary-bg);
-  color: var(--color-button-secondary-text);
-  font-weight: 600;
-  line-height: 1.2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0.375rem;
+  border: 0;
+  background: transparent;
+  color: color-mix(in srgb, var(--color-button-secondary-text) 72%, transparent);
   cursor: pointer;
+  opacity: 0.9;
+  transition: color 160ms ease, opacity 160ms ease, transform 160ms ease;
 }
 
 .theme-toggle:hover {
-  border-color: var(--color-secondary);
   color: var(--color-secondary);
+  opacity: 1;
+}
+
+.theme-toggle:focus-visible {
+  outline: 1px solid color-mix(in srgb, var(--color-secondary) 50%, transparent);
+  outline-offset: 2px;
+  border-radius: 999px;
+}
+
+.theme-toggle:active {
+  transform: translateY(1px);
+}
+
+.theme-toggle__icon {
+  width: 1.375rem;
+  height: 1.375rem;
 }
 
 .app-main {
@@ -660,6 +679,12 @@ a:hover {
     min-height: 3rem;
     padding: 0.75rem 1.25rem;
     font-size: 0.95rem;
+  }
+
+  .theme-toggle {
+    width: 2rem;
+    height: 2rem;
+    padding: 0.25rem;
   }
 }
 

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -10,6 +10,48 @@ function applyTheme(theme: ThemeMode) {
   document.documentElement.dataset.theme = theme;
 }
 
+function SunIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="theme-toggle__icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="3.5" />
+      <path d="M12 2.75v2.5" />
+      <path d="M12 18.75v2.5" />
+      <path d="M21.25 12h-2.5" />
+      <path d="M5.25 12h-2.5" />
+      <path d="M18.54 5.46l-1.77 1.77" />
+      <path d="M7.23 16.77l-1.77 1.77" />
+      <path d="M18.54 18.54l-1.77-1.77" />
+      <path d="M7.23 7.23 5.46 5.46" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="theme-toggle__icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M19 14.5A7.5 7.5 0 0 1 9.5 5a8.5 8.5 0 1 0 9.5 9.5Z" />
+    </svg>
+  );
+}
+
 export function ThemeToggle() {
   const [theme, setTheme] = useState<ThemeMode>(() => {
     if (typeof window === "undefined") {
@@ -40,7 +82,7 @@ export function ThemeToggle() {
       onClick={handleToggle}
       type="button"
     >
-      {theme === "dark" ? "Light Mode" : "Dark Mode"}
+      {theme === "dark" ? <SunIcon /> : <MoonIcon />}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
Replaced text-based theme toggle with a subtle icon-only control to improve header hierarchy.

## Related Issue
Closes #115 

## Changes
- replaced Light/Dark text button with minimal sun/moon icon
- reduced size and visual weight of theme toggle
- preserved existing toggle functionality and accessibility

## Verification checklist
- [ ] icon is visible but subtle on desktop
- [ ] CTA remains dominant
- [ ] mobile header remains clean
- [ ] theme toggle works correctly
- [ ] no layout issues introduced

## Notes
Presentation-only change. No impact to layout structure, flow, or functionality.