### PR TITLE
Issue 6-19: replace placeholder visuals with real assets

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -547,6 +547,20 @@ a:hover {
   object-fit: cover;
 }
 
+.public-image-frame--editorial {
+  max-width: 40rem;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 18px;
+  box-shadow: 0 22px 52px rgba(17, 24, 39, 0.12);
+}
+
+.public-image-frame--editorial img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
 /* ==========================================================================
    Public cards and visual blocks
    ========================================================================== */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-// import Image from "next/image";
+import Image from "next/image";
 
 export default function HomePage() {
   return (
@@ -134,6 +134,16 @@ export default function HomePage() {
             See how the summit is structured, what the themes cover, and how the
             experience is built to move people from reflection into action.
           </p>
+        </div>
+        <div className="public-image-band">
+          <div className="public-image-frame public-image-frame--band public-image-frame--editorial">
+            <Image
+              alt="Bill standing on a navy flight deck, reinforcing the summit's leadership and transition context."
+              height="582"
+              src="/assets/images/bill-navy-flight-deck.jpg"
+              width="581"
+            />
+          </div>
         </div>
         <div className="public-actions">
           <Link className="public-link" href="/summit">

--- a/app/summit/page.tsx
+++ b/app/summit/page.tsx
@@ -25,9 +25,9 @@ export default function SummitPage() {
           <div className="public-hero__media">
             <div className="public-image-frame public-image-frame--hero">
               <Image
-                alt="Summit overview visual with a three-day structure and partner-ready event framing."
+                alt="Bill greeting and connecting in a leadership setting that reflects the summit's real-world tone."
                 height="800"
-                src="/success-summit-overview.svg"
+                src="/assets/images/bill-navy-handshake.jpg"
                 width="1600"
               />
             </div>


### PR DESCRIPTION
## Summary
Replaces placeholder visuals with existing real assets to make the public site feel more credible.

## Related Issue
Closes #120 

## Changes
- Replaced the Summit support visual with a real-world handshake image
- Added a restrained editorial image to the landing Summit band
- Added a small editorial frame variant for visual consistency

## Verification checklist
- [x] npm run lint
- [x] npm run build

## Notes
Existing raw `<img>` warnings remain unchanged. Asset fit may be refined later when Bill provides final imagery.