### PR TITLE
Issue 7-1: Capture summit interest without checkout

### DIFF
--- a/app/register/actions.ts
+++ b/app/register/actions.ts
@@ -59,5 +59,5 @@ export async function submitRegistration(
   const draft = buildRegistrationDraft(values);
   await writeRegistrationDraft(draft);
 
-  redirect("/confirmation");
+  redirect("/register/success");
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -27,8 +27,8 @@ export default async function RegisterPage({
           Register your interest.
         </h1>
         <p className="register-page__lede">
-          Share a few details to reserve your spot. We&apos;ll follow up with
-          event details, updates, and next steps for the summit.
+          Share your name and email to join the list. We&apos;ll follow up with
+          Summit updates as details are confirmed.
         </p>
 
         {error === "draft" ? (
@@ -65,13 +65,13 @@ export default async function RegisterPage({
           <section className="register-panel">
             <h2>What happens next</h2>
             <ol>
-              <li>Complete your registration details.</li>
-              <li>We save your interest and reserve your spot.</li>
-              <li>We follow up with details, updates, and next steps.</li>
+              <li>Share your name and email.</li>
+              <li>We save your interest in the existing registration system.</li>
+              <li>We follow up with Summit updates as details are confirmed.</li>
             </ol>
             <p className="register-panel__note">
-              If you&apos;re still deciding, that&apos;s fine. This form keeps the
-              next step simple and gives us a clear way to follow up.
+              If you&apos;re still deciding, that&apos;s fine. This keeps the next
+              step simple and gives us a clear way to follow up.
             </p>
           </section>
         </aside>

--- a/app/register/register-form.tsx
+++ b/app/register/register-form.tsx
@@ -128,20 +128,11 @@ export function RegisterForm({
 
       <div className="register-form__grid">
         <RegisterField
-          autoComplete="given-name"
-          defaultValue={defaultValues.firstName}
-          error={state.fieldErrors.firstName}
-          label="First name"
-          name="firstName"
-          required
-        />
-
-        <RegisterField
-          autoComplete="family-name"
-          defaultValue={defaultValues.lastName}
-          error={state.fieldErrors.lastName}
-          label="Last name"
-          name="lastName"
+          autoComplete="name"
+          defaultValue={defaultValues.name}
+          error={state.fieldErrors.name}
+          label="Name"
+          name="name"
           required
         />
 
@@ -155,42 +146,14 @@ export function RegisterForm({
           required
           type="email"
         />
-
-        <RegisterField
-          autoComplete="tel"
-          defaultValue={defaultValues.phone}
-          inputMode="tel"
-          label="Phone"
-          name="phone"
-          type="tel"
-        />
-
-        <RegisterField
-          defaultValue={defaultValues.organization}
-          label="Organization / School / Team"
-          name="organization"
-        />
-
-        <RegisterField
-          defaultValue={defaultValues.role}
-          label="Role or affiliation"
-          name="role"
-        />
-
-        <RegisterField
-          defaultValue={defaultValues.notes}
-          label="What are you hoping to get from the summit?"
-          name="notes"
-          rows={5}
-        />
       </div>
 
       <div className="register-cta">
         <div className="register-cta__content">
-          <h2>Reserve your spot</h2>
+          <h2>Register your interest</h2>
           <p>
-            Register your interest now. We&apos;ll save your details and follow
-            up with event information, updates, and next steps.
+            Share your name and email. We&apos;ll save your interest and follow up
+            with Summit updates as details are confirmed.
           </p>
         </div>
         <button

--- a/app/register/registration.ts
+++ b/app/register/registration.ts
@@ -21,38 +21,15 @@ function normalizeSingleLine(value: string) {
   return value.trim().replace(/\s+/g, " ");
 }
 
-function normalizeMultiline(value: string) {
-  return value
-    .replace(/\r\n/g, "\n")
-    .split("\n")
-    .map((line) => line.trim())
-    .join("\n")
-    .trim();
-}
-
 function asRegistrationValues(
   value: Partial<Record<keyof RegistrationFormValues, unknown>>,
 ): RegistrationFormValues {
   return {
-    firstName:
-      typeof value.firstName === "string"
-        ? normalizeSingleLine(value.firstName)
-        : "",
-    lastName:
-      typeof value.lastName === "string" ? normalizeSingleLine(value.lastName) : "",
+    name: typeof value.name === "string" ? normalizeSingleLine(value.name) : "",
     email:
       typeof value.email === "string"
         ? normalizeSingleLine(value.email).toLowerCase()
         : "",
-    phone:
-      typeof value.phone === "string" ? normalizeSingleLine(value.phone) : "",
-    organization:
-      typeof value.organization === "string"
-        ? normalizeSingleLine(value.organization)
-        : "",
-    role: typeof value.role === "string" ? normalizeSingleLine(value.role) : "",
-    notes:
-      typeof value.notes === "string" ? normalizeMultiline(value.notes) : "",
   };
 }
 
@@ -60,13 +37,8 @@ export function normalizeRegistrationValues(
   formData: FormData,
 ): RegistrationFormValues {
   return asRegistrationValues({
-    firstName: getStringValue(formData, "firstName"),
-    lastName: getStringValue(formData, "lastName"),
+    name: getStringValue(formData, "name"),
     email: getStringValue(formData, "email"),
-    phone: getStringValue(formData, "phone"),
-    organization: getStringValue(formData, "organization"),
-    role: getStringValue(formData, "role"),
-    notes: getStringValue(formData, "notes"),
   });
 }
 
@@ -75,12 +47,8 @@ export function validateRegistrationValues(
 ): RegisterFormState["fieldErrors"] {
   const fieldErrors: RegisterFormState["fieldErrors"] = {};
 
-  if (!values.firstName) {
-    fieldErrors.firstName = "Enter your first name.";
-  }
-
-  if (!values.lastName) {
-    fieldErrors.lastName = "Enter your last name.";
+  if (!values.name) {
+    fieldErrors.name = "Enter your name.";
   }
 
   if (!values.email) {

--- a/app/register/success/page.tsx
+++ b/app/register/success/page.tsx
@@ -17,9 +17,7 @@ export default async function RegisterSuccessPage() {
           You&apos;re on the list.
         </h1>
         <p className="register-success-page__lede">
-          {draft.firstName} {draft.lastName}, we&apos;ve received your
-          registration. We&apos;ll follow up with event details, updates, and
-          next steps.
+          We&apos;ll share Summit updates as details are confirmed.
         </p>
       </div>
 
@@ -27,20 +25,18 @@ export default async function RegisterSuccessPage() {
         <section className="register-success-section">
           <h2>What happens next</h2>
           <ol className="register-success-list">
-            <li>Your registration details are saved.</li>
-            <li>We&apos;ll share updates as event planning progresses.</li>
-            <li>You&apos;ll receive next steps directly from the summit team.</li>
+            <li>Your interest is saved in the registration system.</li>
+            <li>We&apos;ll share Summit updates as details are confirmed.</li>
+            <li>No payment step is required right now.</li>
           </ol>
         </section>
 
         <section className="register-success-section">
-          <h2>Registration summary</h2>
+          <h2>Saved details</h2>
+          <p>{draft.name}</p>
           <p>{draft.email}</p>
-          {draft.organization ? <p>{draft.organization}</p> : null}
-          {draft.role ? <p>{draft.role}</p> : null}
           <p className="register-success-section__note">
-            Need to adjust something? Return to registration and update your
-            details.
+            Need to adjust something? Return to registration and submit again.
           </p>
         </section>
       </div>
@@ -49,16 +45,16 @@ export default async function RegisterSuccessPage() {
         <div className="register-success-actions__content">
           <h2>Keep moving</h2>
           <p>
-            Review the summit details again or return to registration if you
+            Review the Summit details again or return to registration if you
             want to change anything before we follow up.
           </p>
         </div>
         <div className="register-success-actions__links">
-          <Link className="register-success-actions__primary" href="/confirmation">
-            View Confirmation
+          <Link className="register-success-actions__primary" href="/summit">
+            Back to Summit
           </Link>
           <Link className="register-success-actions__secondary" href="/register">
-            Edit Registration
+            Register Again
           </Link>
         </div>
       </section>

--- a/app/register/types.ts
+++ b/app/register/types.ts
@@ -1,11 +1,6 @@
 export type RegistrationFormValues = {
-  firstName: string;
-  lastName: string;
+  name: string;
   email: string;
-  phone: string;
-  organization: string;
-  role: string;
-  notes: string;
 };
 
 export type RegistrationDraft = RegistrationFormValues & {
@@ -23,11 +18,6 @@ export type DuplicateRegistrationStatus = "created" | "duplicate";
 export const REGISTRATION_HONEYPOT_FIELD = "website";
 
 export const EMPTY_REGISTRATION_FORM_VALUES: RegistrationFormValues = {
-  firstName: "",
-  lastName: "",
+  name: "",
   email: "",
-  phone: "",
-  organization: "",
-  role: "",
-  notes: "",
 };

--- a/lib/registration-store.ts
+++ b/lib/registration-store.ts
@@ -24,10 +24,6 @@ type RegistrationRow = {
   organization_or_affiliation: string | null;
 };
 
-function buildFullName(values: RegistrationFormValues) {
-  return `${values.firstName} ${values.lastName}`.trim();
-}
-
 export async function initializeRegistrationStore() {
   if (!registrationsTablePromise) {
     registrationsTablePromise = getDb()
@@ -78,10 +74,10 @@ export async function createRegistration(
         organization_or_affiliation
       ) VALUES ($1, $2, $3, $4)`,
       [
-        buildFullName(values),
+        values.name,
         values.email,
         values.email,
-        values.organization || null,
+        null,
       ],
     );
 


### PR DESCRIPTION
## Summary
- Changed registration into an interest-only flow.
- Captures name and email using existing registration storage.
- Stops at `/register/success` instead of moving toward checkout.

## Related Issue
Closes #128 

## Changes
- Simplified register form fields.
- Reused existing registration persistence.
- Updated success copy for interest capture.
- Avoided Stripe/payment changes.

## Verification checklist
- [x] `npm run build`
- [x] `npm run lint`
- [x] Submitted test interest locally
- [x] Verified DB row was created
- [x] Verified no checkout was triggered