### PR TITLE
Issue 7-10: Establish content source layer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
+import { landingContent } from "@/lib/content/landing";
+import { partnersContent } from "@/lib/content/partners";
 
 export default function HomePage() {
   return (
@@ -15,23 +17,22 @@ export default function HomePage() {
 
             <div className="public-hero-poster__overlay">
               <div className="public-hero-poster__content">
-                <p className="public-section__eyebrow">The Success Summit</p>
+                <p className="public-section__eyebrow">{landingContent.hero.eyebrow}</p>
 
                 <h1 className="public-section__title">
-                  Find Your Direction — Keep Dominating
+                  {landingContent.hero.title}
                 </h1>
 
                 <p className="public-section__body public-section__body--spaced">
-                  A focused experience for athletes and veterans navigating transition,
-                  built on alignment, clarity, and execution.
+                  {landingContent.hero.body}
                 </p>
 
                 <div className="public-actions">
                   <Link href="/summit" className="public-button">
-                    View Summit
+                    {landingContent.hero.primaryCta}
                   </Link>
                   <Link href="/register" className="public-link public-link--on-dark">
-                    Register Interest
+                    {landingContent.hero.secondaryCta}
                   </Link>
                 </div>
               </div>
@@ -41,98 +42,67 @@ export default function HomePage() {
       </section>
 
       <section className="public-section public-section--bordered public-section--trust">
-        <p className="public-section__eyebrow">Why This Room Matters</p>
-        <h2 className="public-section__heading">Built for real transition, not generic advice</h2>
+        <p className="public-section__eyebrow">{landingContent.trust.eyebrow}</p>
+        <h2 className="public-section__heading">{landingContent.trust.heading}</h2>
         <div className="audience-grid audience-grid--full">
-          <section className="audience-card">
-            <h3>Who it is for</h3>
-            <p>
-              Athletes, veterans, and professionals carrying pressure, momentum,
-              and a real next decision.
-            </p>
-          </section>
-          <section className="audience-card">
-            <h3>What they get</h3>
-            <p>
-              Clear perspective, practical direction, and a room shaped around
-              execution instead of noise.
-            </p>
-          </section>
-          <section className="audience-card">
-            <h3>Why it is credible</h3>
-            <p>
-              The summit is structured around leadership, transition, and
-              real-world application, not abstract motivation.
-            </p>
-          </section>
+          {landingContent.trust.cards.map((card) => (
+            <section className="audience-card" key={card.title}>
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+            </section>
+          ))}
         </div>
         <div className="public-actions public-actions--trust">
           <Link className="public-button" href="/summit">
-            View Summit
+            {landingContent.trust.primaryCta}
           </Link>
           <Link className="public-link" href="/register">
-            Register Interest
+            {landingContent.trust.secondaryCta}
           </Link>
         </div>
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Who It&apos;s For</p>
-        <h2 className="public-section__heading">A focused room for people navigating what&apos;s next</h2>
+        <p className="public-section__eyebrow">{landingContent.audience.eyebrow}</p>
+        <h2 className="public-section__heading">{landingContent.audience.heading}</h2>
         <div className="audience-grid audience-grid--full">
-          <div className="audience-card">Student Veterans</div>
-          <div className="audience-card">Veterans</div>
-          <div className="audience-card">Student-Athletes</div>
-          <div className="audience-card">Athletic Leaders</div>
-          <div className="audience-card">Corporate Professionals</div>
+          {landingContent.audience.items.map((item) => (
+            <div className="audience-card" key={item}>
+              {item}
+            </div>
+          ))}
         </div>
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Three Themes</p>
-        <h2 className="public-section__heading">Focused on what moves people forward</h2>
+        <p className="public-section__eyebrow">{landingContent.themes.eyebrow}</p>
+        <h2 className="public-section__heading">{landingContent.themes.heading}</h2>
         <div className="public-theme-grid">
-          <section className="public-theme-card">
-            <h3>Mental Success</h3>
-            <p>
-              Build the mindset, discipline, and resilience needed to lead well
-              under pressure.
-            </p>
-          </section>
-          <section className="public-theme-card">
-            <h3>Transition Success</h3>
-            <p>
-              Navigate change with more clarity, better direction, and fewer
-              avoidable missteps.
-            </p>
-          </section>
-          <section className="public-theme-card">
-            <h3>Actions for Success</h3>
-            <p>
-              Leave with practical moves you can apply in work, leadership, and
-              life after the event.
-            </p>
-          </section>
+          {landingContent.themes.cards.map((card) => (
+            <section className="public-theme-card" key={card.title}>
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+            </section>
+          ))}
         </div>
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">What You&apos;ll Gain</p>
-        <h2 className="public-section__heading">Practical value you can act on</h2>
+        <p className="public-section__eyebrow">{landingContent.gains.eyebrow}</p>
+        <h2 className="public-section__heading">{landingContent.gains.heading}</h2>
         <ul className="public-section__list">
-          <li>leave with clearer direction</li>
-          <li>turn pressure into practical next steps</li>
-          <li>build stronger alignment for what comes next</li>
+          {landingContent.gains.items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
         </ul>
       </section>
 
       <section className="public-section public-section--bordered public-section--centered">
-        <p className="public-section__eyebrow">Summit</p>
-        <h2 className="public-section__heading">A clear view of the full experience</h2>
+        <p className="public-section__eyebrow">{landingContent.summitPreview.eyebrow}</p>
+        <h2 className="public-section__heading">{landingContent.summitPreview.heading}</h2>
         <div className="public-section__copy">
           <p className="public-section__body">
-            See how the summit is structured, what the themes cover, and how the
-            experience is built to move people from reflection into action.
+            {landingContent.summitPreview.body}
           </p>
         </div>
         <div className="public-image-band">
@@ -147,78 +117,48 @@ export default function HomePage() {
         </div>
         <div className="public-actions">
           <Link className="public-link" href="/summit">
-            Explore the Summit
+            {landingContent.summitPreview.cta}
           </Link>
         </div>
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Resources</p>
-        <h2 className="public-section__heading">Practical takeaways, previewed simply</h2>
+        <p className="public-section__eyebrow">{landingContent.resources.eyebrow}</p>
+        <h2 className="public-section__heading">{landingContent.resources.heading}</h2>
         <div className="public-theme-grid">
-          <section className="public-theme-card">
-            <h3>Decision frameworks</h3>
-            <p>
-              Learn practical ways to sort through competing priorities and make
-              the next move with more confidence.
-            </p>
-          </section>
-          <section className="public-theme-card">
-            <h3>Leadership application</h3>
-            <p>
-              Take away ideas that apply to work, team settings, and transition
-              moments beyond the event itself.
-            </p>
-          </section>
-          <section className="public-theme-card">
-            <h3>Momentum tools</h3>
-            <p>
-              Leave with simple next-step thinking you can use immediately instead
-              of a heavy content library.
-            </p>
-          </section>
+          {landingContent.resources.cards.map((card) => (
+            <section className="public-theme-card" key={card.title}>
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+            </section>
+          ))}
         </div>
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Partners</p>
-        <h2 className="public-section__heading">Built to welcome credible support</h2>
+        <p className="public-section__eyebrow">{partnersContent.landing.eyebrow}</p>
+        <h2 className="public-section__heading">{partnersContent.landing.heading}</h2>
         <div className="audience-grid audience-grid--full">
-          <section className="audience-card">
-            <h3>Logo-ready placement</h3>
-            <p>
-              Future partner marks and outbound links can live here without
-              changing the page structure.
-            </p>
-          </section>
-          <section className="audience-card">
-            <h3>Mission-aligned support</h3>
-            <p>
-              This space is reserved for organizations that strengthen the summit&apos;s
-              leadership, transition, and performance focus.
-            </p>
-          </section>
-          <section className="audience-card">
-            <h3>Placeholder-safe today</h3>
-            <p>
-              Partner details are intentionally lightweight for now so the page
-              stays credible before sponsor data is finalized.
-            </p>
-          </section>
+          {partnersContent.landing.cards.map((card) => (
+            <section className="audience-card" key={card.title}>
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+            </section>
+          ))}
         </div>
       </section>
 
       <section className="public-section public-section--bordered">
-        <h2 className="public-section__heading">Take the next step with intention</h2>
+        <h2 className="public-section__heading">{landingContent.finalCta.heading}</h2>
         <p className="public-section__body">
-          Review the summit details, then register your interest.
+          {landingContent.finalCta.body}
         </p>
         <div className="public-actions">
           <Link className="public-button" href="/summit">
-            View Summit
+            {landingContent.finalCta.primaryCta}
           </Link>
           <Link className="public-link" href="/register">
-            Register Interest
+            {landingContent.finalCta.secondaryCta}
           </Link>
         </div>
       </section>

--- a/app/summit/page.tsx
+++ b/app/summit/page.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
 import Image from "next/image";
+import { logisticsContent } from "@/lib/content/logistics";
+import { partnersContent } from "@/lib/content/partners";
+import { summitContent } from "@/lib/content/summit";
 
 export default function SummitPage() {
   return (
@@ -7,17 +10,16 @@ export default function SummitPage() {
       <section className="public-section public-section--hero">
         <div className="public-hero page-wrapper--hero">
           <div className="public-hero__content">
-            <h1 className="public-section__title">The Success Summit</h1>
+            <h1 className="public-section__title">{summitContent.hero.title}</h1>
             <p className="public-section__body">
-              A leadership and transition summit for athletes, veterans, and
-              professionals navigating what&apos;s next.
+              {summitContent.hero.body}
             </p>
             <div className="public-actions">
               <Link className="public-button" href="/register">
-                Register Interest
+                {summitContent.hero.primaryCta}
               </Link>
               <Link className="public-link" href="/">
-                View Landing
+                {summitContent.hero.secondaryCta}
               </Link>
             </div>
           </div>
@@ -36,73 +38,39 @@ export default function SummitPage() {
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Speaker Perspective</p>
-        <h2 className="public-section__heading">Credibility comes from the room</h2>
+        <p className="public-section__eyebrow">{summitContent.speakerPerspective.eyebrow}</p>
+        <h2 className="public-section__heading">{summitContent.speakerPerspective.heading}</h2>
         <div className="public-theme-grid">
-          <section className="public-theme-card">
-            <h3>Leadership practitioners</h3>
-            <p>
-              Sessions are built to reflect real leadership pressure, decision-making,
-              and transition work.
-            </p>
-          </section>
-          <section className="public-theme-card">
-            <h3>Athlete and veteran context</h3>
-            <p>
-              The summit is shaped for people moving out of structured environments
-              and into what comes next.
-            </p>
-          </section>
-          <section className="public-theme-card">
-            <h3>Applied conversation</h3>
-            <p>
-              The emphasis is on perspective people can use, not inflated bios or
-              generic inspiration.
-            </p>
-          </section>
+          {summitContent.speakerPerspective.cards.map((card) => (
+            <section className="public-theme-card" key={card.title}>
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+            </section>
+          ))}
         </div>
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Event Overview</p>
-        <h2 className="public-section__heading">A structured summit with real-world relevance</h2>
+        <p className="public-section__eyebrow">{summitContent.overview.eyebrow}</p>
+        <h2 className="public-section__heading">{summitContent.overview.heading}</h2>
         <p className="public-section__body">
-          The Success Summit brings together people navigating leadership,
-          transition, and performance after major shifts in identity, career,
-          and direction.
+          {summitContent.overview.paragraphs[0]}
         </p>
         <p className="public-section__body public-section__body--spaced">
-          It is built for athletes, veterans, university and athletic leaders,
-          and professionals who want practical perspective, stronger alignment,
-          and a credible room to connect in.
+          {summitContent.overview.paragraphs[1]}
         </p>
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Three Themes</p>
-        <h2 className="public-section__heading">Focused on what drives forward motion</h2>
+        <p className="public-section__eyebrow">{summitContent.themes.eyebrow}</p>
+        <h2 className="public-section__heading">{summitContent.themes.heading}</h2>
         <div className="public-theme-grid">
-          <section className="public-theme-card">
-            <h3>Mental Success</h3>
-            <p>
-              Strengthen mindset, resilience, and identity under pressure and
-              change.
-            </p>
-          </section>
-          <section className="public-theme-card">
-            <h3>Transition Success</h3>
-            <p>
-              Clarify direction and align the next chapter with purpose,
-              strengths, and opportunity.
-            </p>
-          </section>
-          <section className="public-theme-card">
-            <h3>Actions for Success</h3>
-            <p>
-              Turn insight into practical next moves across leadership, career,
-              and life.
-            </p>
-          </section>
+          {summitContent.themes.cards.map((card) => (
+            <section className="public-theme-card" key={card.title}>
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+            </section>
+          ))}
         </div>
       </section>
 
@@ -120,92 +88,74 @@ export default function SummitPage() {
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Program Structure</p>
-        <h2 className="public-section__heading">Three days, three focused tracks</h2>
+        <p className="public-section__eyebrow">{summitContent.programStructure.eyebrow}</p>
+        <h2 className="public-section__heading">{summitContent.programStructure.heading}</h2>
         <div className="public-theme-grid">
-          <section className="public-theme-card">
-            <h3>Day 1 — Mental + Identity</h3>
-            <ul className="public-section__list">
-              <li>Mindset, resilience, and personal leadership</li>
-              <li>Identity shifts after sport, service, or role change</li>
-            </ul>
-          </section>
-          <section className="public-theme-card">
-            <h3>Day 2 — Transition + Alignment</h3>
-            <ul className="public-section__list">
-              <li>Career direction, alignment, and next-step clarity</li>
-              <li>Leadership conversations across education, sport, and industry</li>
-            </ul>
-          </section>
-          <section className="public-theme-card">
-            <h3>Day 3 — Action + Execution</h3>
-            <ul className="public-section__list">
-              <li>Practical strategies for momentum after the summit</li>
-              <li>Execution planning, accountability, and connection</li>
-            </ul>
-          </section>
+          {summitContent.programStructure.cards.map((card) => (
+            <section className="public-theme-card" key={card.title}>
+              <h3>{card.title}</h3>
+              <ul className="public-section__list">
+                {card.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
         </div>
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Outcomes</p>
-        <h2 className="public-section__heading">What the experience is built to deliver</h2>
+        <p className="public-section__eyebrow">{summitContent.outcomes.eyebrow}</p>
+        <h2 className="public-section__heading">{summitContent.outcomes.heading}</h2>
         <ul className="public-section__list">
-          <li>clarify the next move</li>
-          <li>strengthen leadership under change</li>
-          <li>leave with practical actions to execute</li>
+          {summitContent.outcomes.items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
         </ul>
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">Logistics</p>
-        <h2 className="public-section__heading">Built for a credible live gathering</h2>
+        <p className="public-section__eyebrow">{logisticsContent.summit.eyebrow}</p>
+        <h2 className="public-section__heading">{logisticsContent.summit.heading}</h2>
         <p className="public-section__body">
-          Location: Indianapolis, IN
+          {logisticsContent.summit.paragraphs[0]}
         </p>
         <p className="public-section__body public-section__body--spaced">
-          Venue: TBD
+          {logisticsContent.summit.paragraphs[1]}
         </p>
         <p className="public-section__body public-section__body--spaced">
-          Final venue and schedule details will be released to registered
-          attendees.
+          {logisticsContent.summit.paragraphs[2]}
         </p>
         <p className="public-section__body public-section__body--spaced">
-          The format is designed to support university, athletic, and
-          leadership partnership opportunities without overextending the event
-          promise.
+          {logisticsContent.summit.paragraphs[3]}
         </p>
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">For Partners & Sponsors</p>
-        <h2 className="public-section__heading">A focused environment for meaningful connection</h2>
+        <p className="public-section__eyebrow">{partnersContent.summit.eyebrow}</p>
+        <h2 className="public-section__heading">{partnersContent.summit.heading}</h2>
         <p className="public-section__body">
-          The summit creates direct access to an audience shaped by leadership,
-          performance, transition, and long-term growth.
+          {partnersContent.summit.paragraphs[0]}
         </p>
         <p className="public-section__body public-section__body--spaced">
-          It offers a leadership-focused environment where sponsors and
-          partners can connect with talent, build visibility, and participate
-          in a credible conversation about what comes next.
+          {partnersContent.summit.paragraphs[1]}
         </p>
         <Link className="public-button" href="/register">
-          Get Involved
+          {partnersContent.summit.cta}
         </Link>
       </section>
 
       <section className="public-section public-section--bordered">
-        <h2 className="public-section__heading">Be part of the summit conversation</h2>
+        <h2 className="public-section__heading">{summitContent.finalCta.heading}</h2>
         <p className="public-section__body">
-          Register interest now and receive event updates as details are
-          finalized.
+          {summitContent.finalCta.body}
         </p>
         <div className="public-actions">
           <Link className="public-button" href="/register">
-            Register Interest
+            {summitContent.finalCta.primaryCta}
           </Link>
           <Link className="public-link" href="/">
-            View Landing
+            {summitContent.finalCta.secondaryCta}
           </Link>
         </div>
       </section>

--- a/lib/content/landing.ts
+++ b/lib/content/landing.ts
@@ -1,0 +1,108 @@
+export const landingContent = {
+  hero: {
+    eyebrow: "The Success Summit",
+    title: "Find Your Direction — Keep Dominating",
+    body:
+      "A focused experience for athletes and veterans navigating transition, built on alignment, clarity, and execution.",
+    primaryCta: "View Summit",
+    secondaryCta: "Register Interest",
+  },
+  trust: {
+    eyebrow: "Why This Room Matters",
+    heading: "Built for real transition, not generic advice",
+    cards: [
+      {
+        title: "Who it is for",
+        body:
+          "Athletes, veterans, and professionals carrying pressure, momentum, and a real next decision.",
+      },
+      {
+        title: "What they get",
+        body:
+          "Clear perspective, practical direction, and a room shaped around execution instead of noise.",
+      },
+      {
+        title: "Why it is credible",
+        body:
+          "The summit is structured around leadership, transition, and real-world application, not abstract motivation.",
+      },
+    ],
+    primaryCta: "View Summit",
+    secondaryCta: "Register Interest",
+  },
+  audience: {
+    eyebrow: "Who It's For",
+    heading: "A focused room for people navigating what's next",
+    items: [
+      "Student Veterans",
+      "Veterans",
+      "Student-Athletes",
+      "Athletic Leaders",
+      "Corporate Professionals",
+    ],
+  },
+  themes: {
+    eyebrow: "Three Themes",
+    heading: "Focused on what moves people forward",
+    cards: [
+      {
+        title: "Mental Success",
+        body:
+          "Build the mindset, discipline, and resilience needed to lead well under pressure.",
+      },
+      {
+        title: "Transition Success",
+        body:
+          "Navigate change with more clarity, better direction, and fewer avoidable missteps.",
+      },
+      {
+        title: "Actions for Success",
+        body:
+          "Leave with practical moves you can apply in work, leadership, and life after the event.",
+      },
+    ],
+  },
+  gains: {
+    eyebrow: "What You'll Gain",
+    heading: "Practical value you can act on",
+    items: [
+      "leave with clearer direction",
+      "turn pressure into practical next steps",
+      "build stronger alignment for what comes next",
+    ],
+  },
+  summitPreview: {
+    eyebrow: "Summit",
+    heading: "A clear view of the full experience",
+    body:
+      "See how the summit is structured, what the themes cover, and how the experience is built to move people from reflection into action.",
+    cta: "Explore the Summit",
+  },
+  resources: {
+    eyebrow: "Resources",
+    heading: "Practical takeaways, previewed simply",
+    cards: [
+      {
+        title: "Decision frameworks",
+        body:
+          "Learn practical ways to sort through competing priorities and make the next move with more confidence.",
+      },
+      {
+        title: "Leadership application",
+        body:
+          "Take away ideas that apply to work, team settings, and transition moments beyond the event itself.",
+      },
+      {
+        title: "Momentum tools",
+        body:
+          "Leave with simple next-step thinking you can use immediately instead of a heavy content library.",
+      },
+    ],
+  },
+  finalCta: {
+    heading: "Take the next step with intention",
+    body: "Review the summit details, then register your interest.",
+    primaryCta: "View Summit",
+    secondaryCta: "Register Interest",
+  },
+} as const;

--- a/lib/content/logistics.ts
+++ b/lib/content/logistics.ts
@@ -1,0 +1,12 @@
+export const logisticsContent = {
+  summit: {
+    eyebrow: "Logistics",
+    heading: "Built for a credible live gathering",
+    paragraphs: [
+      "Location: Indianapolis, IN",
+      "Venue: TBD",
+      "Final venue and schedule details will be released to registered attendees.",
+      "The format is designed to support university, athletic, and leadership partnership opportunities without overextending the event promise.",
+    ],
+  },
+} as const;

--- a/lib/content/partners.ts
+++ b/lib/content/partners.ts
@@ -1,0 +1,32 @@
+export const partnersContent = {
+  landing: {
+    eyebrow: "Partners",
+    heading: "Built to welcome credible support",
+    cards: [
+      {
+        title: "Logo-ready placement",
+        body:
+          "Future partner marks and outbound links can live here without changing the page structure.",
+      },
+      {
+        title: "Mission-aligned support",
+        body:
+          "This space is reserved for organizations that strengthen the summit's leadership, transition, and performance focus.",
+      },
+      {
+        title: "Placeholder-safe today",
+        body:
+          "Partner details are intentionally lightweight for now so the page stays credible before sponsor data is finalized.",
+      },
+    ],
+  },
+  summit: {
+    eyebrow: "For Partners & Sponsors",
+    heading: "A focused environment for meaningful connection",
+    paragraphs: [
+      "The summit creates direct access to an audience shaped by leadership, performance, transition, and long-term growth.",
+      "It offers a leadership-focused environment where sponsors and partners can connect with talent, build visibility, and participate in a credible conversation about what comes next.",
+    ],
+    cta: "Get Involved",
+  },
+} as const;

--- a/lib/content/summit.ts
+++ b/lib/content/summit.ts
@@ -1,0 +1,102 @@
+export const summitContent = {
+  hero: {
+    title: "The Success Summit",
+    body:
+      "A leadership and transition summit for athletes, veterans, and professionals navigating what's next.",
+    primaryCta: "Register Interest",
+    secondaryCta: "View Landing",
+  },
+  speakerPerspective: {
+    eyebrow: "Speaker Perspective",
+    heading: "Credibility comes from the room",
+    cards: [
+      {
+        title: "Leadership practitioners",
+        body:
+          "Sessions are built to reflect real leadership pressure, decision-making, and transition work.",
+      },
+      {
+        title: "Athlete and veteran context",
+        body:
+          "The summit is shaped for people moving out of structured environments and into what comes next.",
+      },
+      {
+        title: "Applied conversation",
+        body:
+          "The emphasis is on perspective people can use, not inflated bios or generic inspiration.",
+      },
+    ],
+  },
+  overview: {
+    eyebrow: "Event Overview",
+    heading: "A structured summit with real-world relevance",
+    paragraphs: [
+      "The Success Summit brings together people navigating leadership, transition, and performance after major shifts in identity, career, and direction.",
+      "It is built for athletes, veterans, university and athletic leaders, and professionals who want practical perspective, stronger alignment, and a credible room to connect in.",
+    ],
+  },
+  themes: {
+    eyebrow: "Three Themes",
+    heading: "Focused on what drives forward motion",
+    cards: [
+      {
+        title: "Mental Success",
+        body:
+          "Strengthen mindset, resilience, and identity under pressure and change.",
+      },
+      {
+        title: "Transition Success",
+        body:
+          "Clarify direction and align the next chapter with purpose, strengths, and opportunity.",
+      },
+      {
+        title: "Actions for Success",
+        body:
+          "Turn insight into practical next moves across leadership, career, and life.",
+      },
+    ],
+  },
+  programStructure: {
+    eyebrow: "Program Structure",
+    heading: "Three days, three focused tracks",
+    cards: [
+      {
+        title: "Day 1 — Mental + Identity",
+        items: [
+          "Mindset, resilience, and personal leadership",
+          "Identity shifts after sport, service, or role change",
+        ],
+      },
+      {
+        title: "Day 2 — Transition + Alignment",
+        items: [
+          "Career direction, alignment, and next-step clarity",
+          "Leadership conversations across education, sport, and industry",
+        ],
+      },
+      {
+        title: "Day 3 — Action + Execution",
+        items: [
+          "Practical strategies for momentum after the summit",
+          "Execution planning, accountability, and connection",
+        ],
+      },
+    ],
+  },
+  outcomes: {
+    eyebrow: "Outcomes",
+    heading: "What the experience is built to deliver",
+    items: [
+      "clarify the next move",
+      "strengthen leadership under change",
+      "leave with practical actions to execute",
+    ],
+  },
+  finalCta: {
+    heading: "Be part of the summit conversation",
+    body:
+      "Register interest now and receive event updates as details are finalized.",
+    primaryCta: "Register Interest",
+    secondaryCta: "View Landing",
+  },
+} as const;


### PR DESCRIPTION
## Summary
Moved public page copy into a simple content source layer.

## Related Issue
Closes #131 

## Changes
- Added structured content files under `lib/content/`
- Updated landing and summit pages to import content directly
- Preserved existing UI, layout, links, and behavior

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Browser smoke test

## Notes
Lint warnings are pre-existing `<img>` warnings.