### PR TITLE
Issue 7-3: Simplify public content

### DIFF
--- a/lib/content/landing.ts
+++ b/lib/content/landing.ts
@@ -3,7 +3,7 @@ export const landingContent = {
     eyebrow: "The Success Summit",
     title: "Find Your Direction — Keep Dominating",
     body:
-      "A focused experience for athletes and veterans navigating transition, built on alignment, clarity, and execution.",
+      "A focused summit for athletes, veterans, and leaders who need direction and a clear next move.",
     primaryCta: "View Summit",
     secondaryCta: "Register Interest",
   },
@@ -14,17 +14,17 @@ export const landingContent = {
       {
         title: "Who it is for",
         body:
-          "Athletes, veterans, and professionals carrying pressure, momentum, and a real next decision.",
+          "People carrying pressure, momentum, and a real next decision.",
       },
       {
         title: "What they get",
         body:
-          "Clear perspective, practical direction, and a room shaped around execution instead of noise.",
+          "Clear direction, practical perspective, and a room built for action.",
       },
       {
         title: "Why it is credible",
         body:
-          "The summit is structured around leadership, transition, and real-world application, not abstract motivation.",
+          "The summit is grounded in leadership, transition, and real-world application.",
       },
     ],
     primaryCta: "View Summit",
@@ -48,17 +48,17 @@ export const landingContent = {
       {
         title: "Mental Success",
         body:
-          "Build the mindset, discipline, and resilience needed to lead well under pressure.",
+          "Build resilience and steadiness under pressure.",
       },
       {
         title: "Transition Success",
         body:
-          "Navigate change with more clarity, better direction, and fewer avoidable missteps.",
+          "Move through change with more clarity and fewer false starts.",
       },
       {
         title: "Actions for Success",
         body:
-          "Leave with practical moves you can apply in work, leadership, and life after the event.",
+          "Leave with actions you can use right away.",
       },
     ],
   },
@@ -75,7 +75,7 @@ export const landingContent = {
     eyebrow: "Summit",
     heading: "A clear view of the full experience",
     body:
-      "See how the summit is structured, what the themes cover, and how the experience is built to move people from reflection into action.",
+      "See how the summit is organized and what you can expect from the experience.",
     cta: "Explore the Summit",
   },
   resources: {
@@ -85,17 +85,17 @@ export const landingContent = {
       {
         title: "Decision frameworks",
         body:
-          "Learn practical ways to sort through competing priorities and make the next move with more confidence.",
+          "Simple ways to sort priorities and make the next move with confidence.",
       },
       {
         title: "Leadership application",
         body:
-          "Take away ideas that apply to work, team settings, and transition moments beyond the event itself.",
+          "Ideas you can apply in work, team settings, and transition moments.",
       },
       {
         title: "Momentum tools",
         body:
-          "Leave with simple next-step thinking you can use immediately instead of a heavy content library.",
+          "Simple next-step tools you can use immediately.",
       },
     ],
   },

--- a/lib/content/summit.ts
+++ b/lib/content/summit.ts
@@ -2,7 +2,7 @@ export const summitContent = {
   hero: {
     title: "The Success Summit",
     body:
-      "A leadership and transition summit for athletes, veterans, and professionals navigating what's next.",
+      "A leadership and transition summit for people who need clarity on what comes next.",
     primaryCta: "Register Interest",
     secondaryCta: "View Landing",
   },
@@ -13,17 +13,17 @@ export const summitContent = {
       {
         title: "Leadership practitioners",
         body:
-          "Sessions are built to reflect real leadership pressure, decision-making, and transition work.",
+          "Sessions reflect real leadership pressure, decisions, and change.",
       },
       {
         title: "Athlete and veteran context",
         body:
-          "The summit is shaped for people moving out of structured environments and into what comes next.",
+          "Built for people moving out of structured environments and into the next chapter.",
       },
       {
         title: "Applied conversation",
         body:
-          "The emphasis is on perspective people can use, not inflated bios or generic inspiration.",
+          "The focus is practical perspective, not generic inspiration.",
       },
     ],
   },
@@ -31,8 +31,8 @@ export const summitContent = {
     eyebrow: "Event Overview",
     heading: "A structured summit with real-world relevance",
     paragraphs: [
-      "The Success Summit brings together people navigating leadership, transition, and performance after major shifts in identity, career, and direction.",
-      "It is built for athletes, veterans, university and athletic leaders, and professionals who want practical perspective, stronger alignment, and a credible room to connect in.",
+      "The Success Summit brings together people navigating leadership, transition, and performance after major change.",
+      "It is built for athletes, veterans, and leaders who want practical perspective and a clear next step.",
     ],
   },
   themes: {
@@ -42,17 +42,17 @@ export const summitContent = {
       {
         title: "Mental Success",
         body:
-          "Strengthen mindset, resilience, and identity under pressure and change.",
+          "Strengthen mindset and resilience under pressure.",
       },
       {
         title: "Transition Success",
         body:
-          "Clarify direction and align the next chapter with purpose, strengths, and opportunity.",
+          "Clarify direction for the next chapter.",
       },
       {
         title: "Actions for Success",
         body:
-          "Turn insight into practical next moves across leadership, career, and life.",
+          "Turn insight into practical next moves.",
       },
     ],
   },
@@ -95,7 +95,7 @@ export const summitContent = {
   finalCta: {
     heading: "Be part of the summit conversation",
     body:
-      "Register interest now and receive event updates as details are finalized.",
+      "Register interest to receive summit updates as details are finalized.",
     primaryCta: "Register Interest",
     secondaryCta: "View Landing",
   },


### PR DESCRIPTION
## Summary
Simplified public-facing copy across the landing and summit content layer.

## Related Issue
Closes #133 

## Changes
- Tightened landing page copy
- Tightened summit page copy
- Reduced repeated messaging
- Kept all changes inside `lib/content/`

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] CTAs unchanged

## Notes
Lint warnings are pre-existing `<img>` warnings.