### PR TITLE
Issue 7-5: Add partners credibility section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -63,6 +63,25 @@ export default function HomePage() {
       </section>
 
       <section className="public-section public-section--bordered">
+        <h2 className="public-section__heading">{partnersContent.landing.heading}</h2>
+        <p className="public-section__body">{partnersContent.landing.subheading}</p>
+        <div className="audience-grid audience-grid--full">
+          {partnersContent.landing.partners.map((partner) => (
+            <section className="audience-card" key={partner.name}>
+              <h3>{partner.name}</h3>
+              {partner.role ? <p>{partner.role}</p> : null}
+              <p>{partner.description}</p>
+            </section>
+          ))}
+        </div>
+        <div className="public-actions">
+          <Link className="public-link" href={partnersContent.landing.cta.href}>
+            {partnersContent.landing.cta.label}
+          </Link>
+        </div>
+      </section>
+
+      <section className="public-section public-section--bordered">
         <p className="public-section__eyebrow">{landingContent.audience.eyebrow}</p>
         <h2 className="public-section__heading">{landingContent.audience.heading}</h2>
         <div className="audience-grid audience-grid--full">
@@ -128,19 +147,6 @@ export default function HomePage() {
         <div className="public-theme-grid">
           {landingContent.resources.cards.map((card) => (
             <section className="public-theme-card" key={card.title}>
-              <h3>{card.title}</h3>
-              <p>{card.body}</p>
-            </section>
-          ))}
-        </div>
-      </section>
-
-      <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">{partnersContent.landing.eyebrow}</p>
-        <h2 className="public-section__heading">{partnersContent.landing.heading}</h2>
-        <div className="audience-grid audience-grid--full">
-          {partnersContent.landing.cards.map((card) => (
-            <section className="audience-card" key={card.title}>
               <h3>{card.title}</h3>
               <p>{card.body}</p>
             </section>

--- a/app/summit/page.tsx
+++ b/app/summit/page.tsx
@@ -115,16 +115,19 @@ export default function SummitPage() {
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">{partnersContent.summit.eyebrow}</p>
         <h2 className="public-section__heading">{partnersContent.summit.heading}</h2>
-        <p className="public-section__body">
-          {partnersContent.summit.paragraphs[0]}
-        </p>
-        <p className="public-section__body public-section__body--spaced">
-          {partnersContent.summit.paragraphs[1]}
-        </p>
-        <Link className="public-button" href="/register">
-          {partnersContent.summit.cta}
+        <p className="public-section__body">{partnersContent.summit.subheading}</p>
+        <div className="audience-grid audience-grid--full">
+          {partnersContent.summit.partners.map((partner) => (
+            <section className="audience-card" key={partner.name}>
+              <h3>{partner.name}</h3>
+              {partner.role ? <p>{partner.role}</p> : null}
+              <p>{partner.description}</p>
+            </section>
+          ))}
+        </div>
+        <Link className="public-button" href={partnersContent.summit.cta.href}>
+          {partnersContent.summit.cta.label}
         </Link>
       </section>
 

--- a/lib/content/partners.ts
+++ b/lib/content/partners.ts
@@ -1,32 +1,66 @@
 export const partnersContent = {
   landing: {
-    eyebrow: "Partners",
-    heading: "Built to welcome credible support",
-    cards: [
+    heading: "Partners who fit the room",
+    subheading:
+      "These partners strengthen the summit with real alignment, real access, and credible support.",
+    partners: [
       {
-        title: "Logo-ready placement",
-        body:
-          "Future partner marks and outbound links can live here without changing the page structure.",
+        name: "University leaders",
+        role: "Student transition",
+        description:
+          "Relevant for students, veterans, and athletes moving into their next chapter.",
+        link: "",
       },
       {
-        title: "Mission-aligned support",
-        body:
-          "This space is reserved for organizations that strengthen the summit's leadership, transition, and performance focus.",
+        name: "Athletic departments",
+        role: "Leadership development",
+        description:
+          "Aligned with performance, identity, and leadership beyond competition.",
+        link: "",
       },
       {
-        title: "Placeholder-safe today",
-        body:
-          "Partner details are intentionally lightweight for now so the page stays credible before sponsor data is finalized.",
+        name: "Employers and sponsors",
+        role: "Career connection",
+        description:
+          "Able to support practical next steps, visibility, and long-term opportunity.",
+        link: "",
       },
     ],
+    cta: {
+      label: "Register Interest",
+      href: "/register",
+    },
   },
   summit: {
-    eyebrow: "For Partners & Sponsors",
-    heading: "A focused environment for meaningful connection",
-    paragraphs: [
-      "The summit creates direct access to an audience shaped by leadership, performance, transition, and long-term growth.",
-      "It offers a leadership-focused environment where sponsors and partners can connect with talent, build visibility, and participate in a credible conversation about what comes next.",
+    heading: "Relevant partners add trust to the experience",
+    subheading:
+      "The summit is built to include partners who understand leadership, transition, and long-term growth.",
+    partners: [
+      {
+        name: "Universities",
+        role: "Student and veteran support",
+        description:
+          "A strong fit for transition, mentorship, and next-step conversations.",
+        link: "",
+      },
+      {
+        name: "Athletic organizations",
+        role: "Performance and identity",
+        description:
+          "Relevant to athletes, coaches, and leaders navigating change.",
+        link: "",
+      },
+      {
+        name: "Mission-aligned employers",
+        role: "Opportunity and exposure",
+        description:
+          "Well positioned to connect with people ready for meaningful next moves.",
+        link: "",
+      },
     ],
-    cta: "Get Involved",
+    cta: {
+      label: "Get Involved",
+      href: "/register",
+    },
   },
 } as const;


### PR DESCRIPTION
## Summary
Added a content-driven Partners section to improve credibility and support conversion.

## Related Issue
Closes #135 

## Changes
- Created structured partner content model in `lib/content/partners.ts`
- Rendered Partners section on landing and summit pages
- Positioned sections to support trust without disrupting CTA flow

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual smoke test (placement and CTAs)

## Notes
Existing `<img>` lint warnings are unchanged.