### PR TITLE
Issue 7-4: Add logistics action hub

### DIFF
--- a/app/summit/page.tsx
+++ b/app/summit/page.tsx
@@ -132,19 +132,28 @@ export default function SummitPage() {
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">{logisticsContent.summit.eyebrow}</p>
-        <h2 className="public-section__heading">{logisticsContent.summit.heading}</h2>
-        <p className="public-section__body">
-          {logisticsContent.summit.paragraphs[0]}
-        </p>
+        <h2 className="public-section__heading">{logisticsContent.heading}</h2>
+        <p className="public-section__body">{logisticsContent.subheading}</p>
+        <ul className="public-section__list">
+          {logisticsContent.details.map((detail) => (
+            <li key={detail.label}>
+              <strong>{detail.label}:</strong> {detail.value}
+            </li>
+          ))}
+        </ul>
+        <div className="public-actions">
+          {logisticsContent.actions.map((action) => (
+            <Link
+              key={action.label}
+              className={action.emphasis === "primary" ? "public-button" : "public-link"}
+              href={action.href}
+            >
+              {action.label}
+            </Link>
+          ))}
+        </div>
         <p className="public-section__body public-section__body--spaced">
-          {logisticsContent.summit.paragraphs[1]}
-        </p>
-        <p className="public-section__body public-section__body--spaced">
-          {logisticsContent.summit.paragraphs[2]}
-        </p>
-        <p className="public-section__body public-section__body--spaced">
-          {logisticsContent.summit.paragraphs[3]}
+          {logisticsContent.note}
         </p>
       </section>
 

--- a/lib/content/logistics.ts
+++ b/lib/content/logistics.ts
@@ -1,12 +1,33 @@
 export const logisticsContent = {
-  summit: {
-    eyebrow: "Logistics",
-    heading: "Built for a credible live gathering",
-    paragraphs: [
-      "Location: Indianapolis, IN",
-      "Venue: TBD",
-      "Final venue and schedule details will be released to registered attendees.",
-      "The format is designed to support university, athletic, and leadership partnership opportunities without overextending the event promise.",
-    ],
-  },
+  heading: "Plan the next step clearly",
+  subheading:
+    "The summit is planned for Indianapolis. Final venue and schedule details will be shared with registered attendees.",
+  details: [
+    {
+      label: "Where",
+      value: "Indianapolis, IN",
+    },
+    {
+      label: "When",
+      value: "Schedule details released to registered attendees",
+    },
+    {
+      label: "Venue",
+      value: "TBD",
+    },
+  ],
+  actions: [
+    {
+      label: "Register Interest",
+      href: "/register",
+      emphasis: "primary",
+    },
+    {
+      label: "View Landing",
+      href: "/",
+      emphasis: "secondary",
+    },
+  ],
+  note:
+    "Register now to receive final location, schedule, and next-step updates as details are confirmed.",
 } as const;


### PR DESCRIPTION
## Summary
Refactored Summit logistics section into a clear, actionable decision hub.

## Related Issue
Closes #134 

## Changes
- Introduced structured logistics content model
- Converted logistics into quick-scan details (where, when, venue)
- Added explicit primary and secondary actions
- Removed passive paragraph-style presentation

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual smoke test (actions + placement)

## Notes
Existing `<img>` lint warnings are unchanged.