### PR TITLE
Issue 7-9: Implement owner-managed admin accounts

### DIFF
--- a/app/api/admin/users/reset-password/route.ts
+++ b/app/api/admin/users/reset-password/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { isCurrentAdminOwner } from "@/lib/admin-auth-server";
 import {
-  disableAdminUser,
   normalizeAdminEmail,
+  resetAdminUserPassword,
 } from "@/lib/admin-user-store";
 
 export async function POST(request: Request) {
@@ -12,37 +12,38 @@ export async function POST(request: Request) {
 
   const formData = await request.formData();
   const normalizedEmailEntry = formData.get("normalizedEmail");
+  const password = formData.get("password");
   const normalizedEmail = normalizeAdminEmail(
     typeof normalizedEmailEntry === "string" ? normalizedEmailEntry : "",
   );
 
-  if (!normalizedEmail) {
+  if (!normalizedEmail || typeof password !== "string") {
     return NextResponse.redirect(
-      new URL("/admin/users?error=disable-invalid", request.url),
+      new URL("/admin/users?error=reset-invalid", request.url),
       303,
     );
   }
 
   try {
-    await disableAdminUser(normalizedEmail);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "disable-invalid";
-
-    if (message === "Keep at least one active owner") {
-      return NextResponse.redirect(
-        new URL("/admin/users?error=keep-owner", request.url),
-        303,
-      );
-    }
-
+    await resetAdminUserPassword({
+      normalizedEmail,
+      password,
+    });
+  } catch {
     return NextResponse.redirect(
-      new URL("/admin/users?error=disable-invalid", request.url),
+      new URL(
+        `/admin/users?error=reset-invalid&manage=${encodeURIComponent(normalizedEmail)}`,
+        request.url,
+      ),
       303,
     );
   }
 
   return NextResponse.redirect(
-    new URL("/admin/users?status=user-disabled", request.url),
+    new URL(
+      `/admin/users?status=password-reset&manage=${encodeURIComponent(normalizedEmail)}`,
+      request.url,
+    ),
     303,
   );
 }

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { isCurrentAdminOwner } from "@/lib/admin-auth-server";
-import { createHelperAdminUser } from "@/lib/admin-user-store";
+import {
+  createManagedAdminUser,
+  parseAdminUserRole,
+} from "@/lib/admin-user-store";
 
 export async function POST(request: Request) {
   if (!(await isCurrentAdminOwner())) {
@@ -10,8 +13,10 @@ export async function POST(request: Request) {
   const formData = await request.formData();
   const email = formData.get("email");
   const password = formData.get("password");
+  const roleValue = formData.get("role");
+  const role = parseAdminUserRole(roleValue);
 
-  if (typeof email !== "string" || typeof password !== "string") {
+  if (typeof email !== "string" || typeof password !== "string" || !role) {
     return NextResponse.redirect(
       new URL("/admin/users?error=invalid", request.url),
       303,
@@ -19,9 +24,10 @@ export async function POST(request: Request) {
   }
 
   try {
-    await createHelperAdminUser({
+    await createManagedAdminUser({
       email,
       password,
+      role,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "invalid";
@@ -40,7 +46,7 @@ export async function POST(request: Request) {
   }
 
   return NextResponse.redirect(
-    new URL("/admin/users?status=helper-added", request.url),
+    new URL("/admin/users?status=user-added", request.url),
     303,
   );
 }

--- a/app/api/admin/users/update/route.ts
+++ b/app/api/admin/users/update/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import {
+  getCurrentAdminUser,
+  isCurrentAdminOwner,
+} from "@/lib/admin-auth-server";
+import {
+  createAdminSessionValue,
+  getAdminSessionCookieName,
+  getAdminSessionCookieOptions,
+} from "@/lib/admin-auth";
+import {
+  normalizeAdminEmail,
+  updateAdminUserEmail,
+} from "@/lib/admin-user-store";
+
+export async function POST(request: Request) {
+  if (!(await isCurrentAdminOwner())) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const formData = await request.formData();
+  const normalizedEmailEntry = formData.get("normalizedEmail");
+  const nextEmail = formData.get("email");
+  const normalizedEmail = normalizeAdminEmail(
+    typeof normalizedEmailEntry === "string" ? normalizedEmailEntry : "",
+  );
+
+  if (!normalizedEmail || typeof nextEmail !== "string") {
+    return NextResponse.redirect(
+      new URL("/admin/users?error=update-invalid", request.url),
+      303,
+    );
+  }
+
+  try {
+    const currentAdminUser = await getCurrentAdminUser();
+    const updatedUser = await updateAdminUserEmail({
+      normalizedEmail,
+      nextEmail,
+    });
+    const response = NextResponse.redirect(
+      new URL(
+        `/admin/users?status=user-updated&manage=${encodeURIComponent(updatedUser.normalizedEmail)}`,
+        request.url,
+      ),
+      303,
+    );
+
+    if (currentAdminUser?.normalizedEmail === normalizedEmail) {
+      const sessionValue = createAdminSessionValue(updatedUser.normalizedEmail);
+
+      if (!sessionValue) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+
+      response.cookies.set({
+        ...getAdminSessionCookieOptions(),
+        name: getAdminSessionCookieName(),
+        value: sessionValue,
+      });
+    }
+
+    return response;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "update-invalid";
+
+    if (message === "That email already has access") {
+      return NextResponse.redirect(
+        new URL(
+          `/admin/users?error=exists&manage=${encodeURIComponent(normalizedEmail)}`,
+          request.url,
+        ),
+        303,
+      );
+    }
+
+    return NextResponse.redirect(
+      new URL(
+        `/admin/users?error=update-invalid&manage=${encodeURIComponent(normalizedEmail)}`,
+        request.url,
+      ),
+      303,
+    );
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1362,7 +1362,8 @@ a:hover {
   line-height: 1.3;
 }
 
-.admin-field input {
+.admin-field input,
+.admin-field select {
   width: 100%;
   min-height: 3.25rem;
   border: 1px solid var(--color-border);
@@ -1373,7 +1374,8 @@ a:hover {
   line-height: 1.5;
 }
 
-.admin-field input:focus {
+.admin-field input:focus,
+.admin-field select:focus {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }

--- a/lib/admin-user-store.ts
+++ b/lib/admin-user-store.ts
@@ -4,6 +4,7 @@ import { getDb } from "@/lib/db";
 
 export const ADMIN_USERS_TABLE = "admin_users";
 const SCRYPT_KEY_LENGTH = 64;
+const MIN_ADMIN_PASSWORD_LENGTH = 8;
 const scrypt = promisify(nodeScrypt);
 
 let adminUsersTablePromise: Promise<void> | null = null;
@@ -32,6 +33,16 @@ export type AdminUserRecord = {
 
 export function normalizeAdminEmail(value: string) {
   return value.trim().toLowerCase();
+}
+
+function validateAdminPassword(password: string) {
+  if (!password) {
+    throw new Error("Admin password is required");
+  }
+
+  if (password.length < MIN_ADMIN_PASSWORD_LENGTH) {
+    throw new Error(`Admin password must be at least ${MIN_ADMIN_PASSWORD_LENGTH} characters`);
+  }
 }
 
 function mapAdminUserRow(row: AdminUserRow): AdminUserRecord {
@@ -174,6 +185,8 @@ export async function initializeAdminUserStore() {
 export async function findAdminUserByNormalizedEmail(
   normalizedEmail: string,
 ): Promise<AdminUserRecord | null> {
+  await initializeAdminUserStore();
+
   const result = await getDb().query<AdminUserRow>(
     `SELECT
       normalized_email,
@@ -208,6 +221,8 @@ export async function authenticateAdminUser(
     return null;
   }
 
+  await initializeAdminUserStore();
+
   const adminUser = await findAdminUserByNormalizedEmail(normalizedEmail);
 
   if (!adminUser) {
@@ -232,15 +247,15 @@ export async function upsertAdminUser({
   password: string;
   role: AdminUserRole;
 }) {
+  await initializeAdminUserStore();
+
   const normalizedEmail = normalizeAdminEmail(email);
 
   if (!normalizedEmail) {
     throw new Error("Admin email is required");
   }
 
-  if (!password) {
-    throw new Error("Admin password is required");
-  }
+  validateAdminPassword(password);
 
   if (!parseAdminUserRole(role)) {
     throw new Error("Admin role must be owner or admin");
@@ -274,6 +289,8 @@ export async function upsertAdminUser({
 }
 
 export async function getOwnerAdminUser(): Promise<AdminUserRecord | null> {
+  await initializeAdminUserStore();
+
   const result = await getDb().query<AdminUserRow>(
     `SELECT
       normalized_email,
@@ -296,6 +313,8 @@ export async function getOwnerAdminUser(): Promise<AdminUserRecord | null> {
 }
 
 export async function listAdminUsers(): Promise<AdminUserRecord[]> {
+  await initializeAdminUserStore();
+
   const result = await getDb().query<AdminUserRow>(
     `SELECT
       normalized_email,
@@ -320,15 +339,15 @@ export async function createHelperAdminUser({
   email: string;
   password: string;
 }) {
+  await initializeAdminUserStore();
+
   const normalizedEmail = normalizeAdminEmail(email);
 
   if (!normalizedEmail) {
     throw new Error("Helper email is required");
   }
 
-  if (!password) {
-    throw new Error("Helper password is required");
-  }
+  validateAdminPassword(password);
 
   const existingUser = await findAdminUserByNormalizedEmail(normalizedEmail);
 
@@ -344,6 +363,8 @@ export async function createHelperAdminUser({
 }
 
 async function countActiveOwners() {
+  await initializeAdminUserStore();
+
   const result = await getDb().query<{ total: string }>(
     `SELECT COUNT(*)::text AS total
      FROM ${ADMIN_USERS_TABLE}
@@ -356,6 +377,8 @@ async function countActiveOwners() {
 export async function disableAdminUser(
   normalizedEmail: string,
 ): Promise<AdminUserRecord> {
+  await initializeAdminUserStore();
+
   const adminUser = await findAdminUserByNormalizedEmail(normalizedEmail);
 
   if (!adminUser) {
@@ -394,6 +417,8 @@ export async function disableAdminUser(
 export async function removeAdminUser(
   normalizedEmail: string,
 ): Promise<AdminUserRecord> {
+  await initializeAdminUserStore();
+
   const adminUser = await findAdminUserByNormalizedEmail(normalizedEmail);
 
   if (!adminUser) {
@@ -415,6 +440,132 @@ export async function removeAdminUser(
       role,
       created_at`,
     [normalizedEmail],
+  );
+
+  if (result.rowCount !== 1) {
+    throw new Error("Admin user not found");
+  }
+
+  return mapAdminUserRow(result.rows[0]);
+}
+
+export async function createManagedAdminUser({
+  email,
+  password,
+  role,
+}: {
+  email: string;
+  password: string;
+  role: AdminUserRole;
+}) {
+  await initializeAdminUserStore();
+
+  const normalizedEmail = normalizeAdminEmail(email);
+
+  if (!normalizedEmail) {
+    throw new Error("Admin email is required");
+  }
+
+  validateAdminPassword(password);
+
+  if (!parseAdminUserRole(role)) {
+    throw new Error("Admin role must be owner or admin");
+  }
+
+  const existingUser = await findAdminUserByNormalizedEmail(normalizedEmail);
+
+  if (existingUser) {
+    throw new Error("That email already has access");
+  }
+
+  return upsertAdminUser({
+    email,
+    password,
+    role,
+  });
+}
+
+export async function updateAdminUserEmail({
+  normalizedEmail,
+  nextEmail,
+}: {
+  normalizedEmail: string;
+  nextEmail: string;
+}) {
+  await initializeAdminUserStore();
+
+  const existingUser = await findAdminUserByNormalizedEmail(normalizedEmail);
+
+  if (!existingUser) {
+    throw new Error("Admin user not found");
+  }
+
+  const nextNormalizedEmail = normalizeAdminEmail(nextEmail);
+
+  if (!nextNormalizedEmail) {
+    throw new Error("Admin email is required");
+  }
+
+  if (nextNormalizedEmail !== normalizedEmail) {
+    const conflictingUser = await findAdminUserByNormalizedEmail(nextNormalizedEmail);
+
+    if (conflictingUser) {
+      throw new Error("That email already has access");
+    }
+  }
+
+  const result = await getDb().query<AdminUserRow>(
+    `UPDATE ${ADMIN_USERS_TABLE}
+     SET normalized_email = $2,
+         email = $3
+     WHERE normalized_email = $1
+     RETURNING
+      normalized_email,
+      email,
+      is_active,
+      password_hash,
+      role,
+      created_at`,
+    [normalizedEmail, nextNormalizedEmail, nextEmail.trim()],
+  );
+
+  if (result.rowCount !== 1) {
+    throw new Error("Admin user not found");
+  }
+
+  return mapAdminUserRow(result.rows[0]);
+}
+
+export async function resetAdminUserPassword({
+  normalizedEmail,
+  password,
+}: {
+  normalizedEmail: string;
+  password: string;
+}) {
+  await initializeAdminUserStore();
+
+  const existingUser = await findAdminUserByNormalizedEmail(normalizedEmail);
+
+  if (!existingUser) {
+    throw new Error("Admin user not found");
+  }
+
+  validateAdminPassword(password);
+
+  const passwordHash = await createAdminPasswordHash(password);
+  const result = await getDb().query<AdminUserRow>(
+    `UPDATE ${ADMIN_USERS_TABLE}
+     SET password_hash = $2
+     WHERE normalized_email = $1
+     RETURNING
+      normalized_email,
+      email,
+      is_active,
+      password_hash,
+      role,
+      created_at`,
+    [normalizedEmail, passwordHash],
   );
 
   if (result.rowCount !== 1) {


### PR DESCRIPTION
## Summary
Enabled owner-managed admin account operations.

## Related Issue
Closes #130 

## Changes
- Added admin user management UI at `/admin/users`
- Implemented create, update email, reset password, disable, and remove flows
- Enforced role-based access (owner/admin)
- Preserved password hashing via scrypt
- Enforced `is_active` at login
- Prevented disabling/removing last active owner
- Refreshed session on self email update

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] Admin routes registered
- [ ] Manual admin flow verification (create/update/reset/disable)

## Notes
- Roles are set at creation; no role-change flow included to keep scope tight
- No email-based recovery (out of scope)
- Admin system is now owner-operable