### PR TITLE
Issue 7-16: Remove landing audience section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -85,18 +85,6 @@ export default function HomePage() {
       </section>
 
       <section className="public-section public-section--bordered">
-        <p className="public-section__eyebrow">{landingContent.audience.eyebrow}</p>
-        <h2 className="public-section__heading">{landingContent.audience.heading}</h2>
-        <div className="audience-grid audience-grid--full">
-          {landingContent.audience.items.map((item) => (
-            <div className="audience-card" key={item}>
-              {item}
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section className="public-section public-section--bordered">
         <p className="public-section__eyebrow">{landingContent.themes.eyebrow}</p>
         <h2 className="public-section__heading">{landingContent.themes.heading}</h2>
         <div className="public-theme-grid">

--- a/lib/content/landing.ts
+++ b/lib/content/landing.ts
@@ -30,17 +30,6 @@ export const landingContent = {
     primaryCta: "View Summit",
     secondaryCta: "Register Interest",
   },
-  audience: {
-    eyebrow: "Who It's For",
-    heading: "A focused room for people navigating what's next",
-    items: [
-      "Student Veterans",
-      "Veterans",
-      "Student-Athletes",
-      "Athletic Leaders",
-      "Corporate Professionals",
-    ],
-  },
   themes: {
     eyebrow: "Three Themes",
     heading: "Focused on what moves people forward",


### PR DESCRIPTION
## Summary
Removed the standalone "Who It's For" section from the landing page.

## Related Issue
Closes #158 

## Changes
- Removed the landing page audience section
- Removed unused `landingContent.audience` content block
- Preserved existing page structure and spacing

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual landing page check

## Notes
The trust card language was left unchanged because this issue only removed the standalone section.