### PR TITLE
Issue 7-18: Fix summit CTA spacing

### DIFF
--- a/app/summit/page.tsx
+++ b/app/summit/page.tsx
@@ -126,9 +126,11 @@ export default function SummitPage() {
             </section>
           ))}
         </div>
-        <Link className="public-button" href={partnersContent.summit.cta.href}>
-          {partnersContent.summit.cta.label}
-        </Link>
+        <div className="public-actions">
+          <Link className="public-button" href={partnersContent.summit.cta.href}>
+            {partnersContent.summit.cta.label}
+          </Link>
+        </div>
       </section>
 
       <section className="public-section public-section--bordered">


### PR DESCRIPTION
## Summary
Fixed CTA spacing in the Summit partners section.

## Related Issue
Closes #163 

## Changes
- Wrapped the partners CTA in the shared `public-actions` container
- Reused existing section spacing pattern
- Preserved layout and copy

## Verification checklist
- [x] `npm run lint`
- [x] `npm run build`
- [x] Desktop visual check
- [x] Mobile visual check

## Notes
No new CSS was needed.